### PR TITLE
Refactor LED configuration options in Kconfig and update sdkconfig.de…

### DIFF
--- a/components/vigilant_engine/CMakeLists.txt
+++ b/components/vigilant_engine/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(requires esp-tls nvs_flash esp_netif esp_http_server driver)
+set(requires esp-tls nvs_flash esp_netif esp_http_server driver esp_driver_gpio)
 idf_build_get_property(target IDF_TARGET)
 idf_build_get_property(build_dir BUILD_DIR)
 

--- a/main/Kconfig.projbuild
+++ b/main/Kconfig.projbuild
@@ -42,18 +42,18 @@ menu "Vigilant Engine Configuration: LEDs"
         help
             Enable this option to use the status LED functionality in Vigilant Engine.
             The status LED provides visual feedback on the system's status and operations, and can optionally be used for visual output.
-    
+
     choice VE_LED_TYPE
         prompt "LED Type"
-        default VE_LED_TYPE_STATUS
+        default VE_LED_TYPE_GENERIC
         depends on VE_ENABLE_STATUS_LED
         help
             Select the type of LED functionality to enable in Vigilant Engine.
 
         config VE_LED_TYPE_WS2812B
             bool "WS2812B LED"
-        
-        config VE_LED_TYPE_NONE
+
+        config VE_LED_TYPE_GENERIC
             bool "Generic LED"
     endchoice
 
@@ -72,18 +72,17 @@ menu "Vigilant Engine Configuration: LEDs"
     choice VE_STATUS_LED_MODE
         prompt "LED Operation Mode"
         default VE_STATUS_LED_MODE_RGB
-        depends on VE_LED_TYPE_NONE
+        depends on VE_LED_TYPE_GENERIC
         help
             Select how the LED conveys status information.
 
         config VE_STATUS_LED_MODE_RGB
             bool "RGB (Color-based)"
-        
+
         config VE_STATUS_LED_MODE_BLINK
             bool "BLINK (Frequency-based)"
     endchoice
 
-    # --- RGB Mode Settings ---
     config VE_STATUS_LED_GPIO_RED
         int "Red LED GPIO"
         range 0 64
@@ -102,7 +101,6 @@ menu "Vigilant Engine Configuration: LEDs"
         default 45
         depends on VE_STATUS_LED_MODE_RGB
 
-    # --- BLINK Mode Settings ---
     config VE_STATUS_LED_GPIO_BLINK
         int "Blink LED GPIO"
         range 0 64

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -31,7 +31,8 @@ CONFIG_HTTPD_SERVER_EVENT_POST_TIMEOUT=2000
 # end of HTTP Server
 
 #Avoid Status LED conflicts
-CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=n
+#CONFIG_ESP_CONSOLE_SECONDARY_USB_SERIAL_JTAG=n
+# !!! THIS LINE IS COMMENTED OUT ON PURPOSE !!! For booleans set to off, the expected form is # CONFIG_NAME is not set, not CONFIG_NAME=n
 
 #To enable logging while using the timer
 #Weirdly also fixes the serial time out?


### PR DESCRIPTION
…faults for clarity

I commented out a line in the `sdkconfig.defaults`, otherwise leading to broken reconfigures on new installations: For booleans set to off, the expected form is # CONFIG_NAME is not set, not CONFIG_NAME=n

@Kampfdackel5 I also took a look at that issue you had in the last PR. It also happened for me. To fix that, I edited the Kconfig file.  