### PR TITLE
Feature/i2c routes

### DIFF
--- a/.github/workflows/esp-build.yml
+++ b/.github/workflows/esp-build.yml
@@ -3,10 +3,8 @@ name: Frontend and Firmware CI
 on:
   push:
     branches:
-      - main
+      - "**"
   pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -52,6 +50,9 @@ jobs:
   firmware:
     runs-on: ubuntu-latest
     needs: frontend
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main')
 
     steps:
       - name: Checkout repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,3 +16,91 @@ idf_build_set_property(MINIMAL_BUILD ON)
 idf_build_set_property(VE_BUILD_WEB "${VE_BUILD_WEB}")
 idf_build_set_property(VE_VIGILANT_HTML "${VE_VIGILANT_HTML}")
 project(vigilant-engine)
+
+idf_build_get_property(VE_BUILD_DIR BUILD_DIR)
+idf_build_get_property(VE_PROJECT_BIN PROJECT_BIN)
+idf_build_get_property(VE_PYTHON PYTHON)
+idf_build_get_property(VE_IDF_TARGET IDF_TARGET)
+idf_build_get_property(VE_IDF_PATH IDF_PATH)
+
+partition_table_get_partition_info(VE_MAIN_APP_OFFSET "--partition-name ota_0" "offset")
+partition_table_get_partition_info(VE_RECOVERY_APP_OFFSET "--partition-name factory" "offset")
+
+if(NOT VE_MAIN_APP_OFFSET)
+    message(FATAL_ERROR "Could not find ota_0 partition offset for main firmware flashing.")
+endif()
+
+if(NOT VE_RECOVERY_APP_OFFSET)
+    message(FATAL_ERROR "Could not find factory partition offset for recovery firmware flashing.")
+endif()
+
+set(VE_RECOVERY_PROJECT_DIR "${CMAKE_SOURCE_DIR}/vigilant-engine-recovery")
+set(VE_RECOVERY_BIN "${VE_RECOVERY_PROJECT_DIR}/build/vigilant-engine-recovery.bin")
+set(VE_RECOVERY_PARTITIONS_CSV "${VE_RECOVERY_PROJECT_DIR}/partitions.csv")
+get_filename_component(VE_PYTHON_BIN_DIR "${VE_PYTHON}" DIRECTORY)
+get_filename_component(VE_PYTHON_ENV_PATH "${VE_PYTHON_BIN_DIR}" DIRECTORY)
+get_filename_component(VE_TOOLCHAIN_BIN_DIR "${CMAKE_C_COMPILER}" DIRECTORY)
+
+set(VE_ESP_IDF_VERSION "$ENV{ESP_IDF_VERSION}")
+if(NOT VE_ESP_IDF_VERSION)
+    set(VE_ESP_IDF_VERSION "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}")
+endif()
+set(VE_IDF_TOOLS_PATH "$ENV{IDF_TOOLS_PATH}")
+if(NOT VE_IDF_TOOLS_PATH)
+    set(VE_IDF_TOOLS_PATH "$ENV{HOME}/.espressif")
+endif()
+set(VE_ESP_ROM_ELF_DIR "$ENV{ESP_ROM_ELF_DIR}")
+
+function(ve_remove_default_project_bin target_name)
+    if(NOT TARGET ${target_name})
+        return()
+    endif()
+
+    foreach(property_name IN ITEMS IMAGES ENCRYPTED_IMAGES NON_ENCRYPTED_IMAGES FLASH_FILE FLASH_ENTRY)
+        get_property(property_values TARGET ${target_name} PROPERTY ${property_name})
+        set(filtered_values)
+
+        foreach(property_value IN LISTS property_values)
+            string(FIND "${property_value}" "${VE_PROJECT_BIN}" project_bin_index)
+            if(project_bin_index EQUAL -1)
+                list(APPEND filtered_values "${property_value}")
+            endif()
+        endforeach()
+
+        set_property(TARGET ${target_name} PROPERTY ${property_name} "${filtered_values}")
+    endforeach()
+endfunction()
+
+ve_remove_default_project_bin(app-flash)
+ve_remove_default_project_bin(flash)
+ve_remove_default_project_bin(encrypted-app-flash)
+ve_remove_default_project_bin(encrypted-flash)
+
+esptool_py_flash_target_image(app-flash app "${VE_MAIN_APP_OFFSET}" "${VE_BUILD_DIR}/${VE_PROJECT_BIN}")
+esptool_py_flash_target_image(flash recovery "${VE_RECOVERY_APP_OFFSET}" "${VE_RECOVERY_BIN}" ALWAYS_PLAINTEXT)
+esptool_py_flash_target_image(flash app "${VE_MAIN_APP_OFFSET}" "${VE_BUILD_DIR}/${VE_PROJECT_BIN}")
+
+add_custom_target(ve_recovery_build
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+            "${CMAKE_SOURCE_DIR}/partitions.csv"
+            "${VE_RECOVERY_PARTITIONS_CSV}"
+    COMMAND "${CMAKE_COMMAND}" -E env
+            "IDF_PATH=${VE_IDF_PATH}"
+            "IDF_TOOLS_PATH=${VE_IDF_TOOLS_PATH}"
+            "IDF_PYTHON_ENV_PATH=${VE_PYTHON_ENV_PATH}"
+            "ESP_IDF_VERSION=${VE_ESP_IDF_VERSION}"
+            "ESP_ROM_ELF_DIR=${VE_ESP_ROM_ELF_DIR}"
+            "PATH=${VE_TOOLCHAIN_BIN_DIR}:$ENV{PATH}"
+            "${VE_PYTHON}" "${VE_IDF_PATH}/tools/idf.py"
+            -C "${VE_RECOVERY_PROJECT_DIR}"
+            -D "IDF_TARGET=${VE_IDF_TARGET}"
+            -D "VE_BUILD_WEB=${VE_BUILD_WEB}"
+            reconfigure build
+    BYPRODUCTS "${VE_RECOVERY_BIN}" "${VE_RECOVERY_PARTITIONS_CSV}"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    USES_TERMINAL
+    VERBATIM
+)
+
+add_dependencies(ve_recovery_build app)
+add_dependencies(flash ve_recovery_build)

--- a/components/vigilant_engine/include/i2c.h
+++ b/components/vigilant_engine/include/i2c.h
@@ -1,5 +1,7 @@
 #pragma once
 
+#include <stddef.h>
+
 #include "esp_err.h"
 #include "vigilant_i2c_device.h"
 
@@ -13,6 +15,7 @@ esp_err_t i2c_remove_device(VigilantI2CDevice *device);
 esp_err_t i2c_set_reg8(VigilantI2CDevice *device, uint8_t reg, uint8_t value);
 esp_err_t i2c_read_reg8(VigilantI2CDevice *device, uint8_t reg, uint8_t *value);
 esp_err_t i2c_whoami_check(VigilantI2CDevice *device);
+esp_err_t i2c_get_detected_devices(uint8_t *addresses, size_t max_addresses, size_t *count);
 void i2c_deinit(void);
 
 #ifdef __cplusplus

--- a/components/vigilant_engine/include/vigilant.h
+++ b/components/vigilant_engine/include/vigilant.h
@@ -33,8 +33,10 @@ typedef struct {
     uint8_t sda_io;
     uint8_t scl_io;
     uint32_t frequency_hz;
-    uint8_t device_count;
-    VigilantI2CDevice devices[8]; // fixed-size array for simplicity; adjust as needed
+    uint8_t added_device_count;
+    VigilantI2CDevice added_devices[8]; // fixed-size array for simplicity; adjust as needed
+    uint8_t detected_device_count;
+    uint8_t detected_devices[16]; // 7-bit addresses detected on the bus
 } VigilantI2cInfo;
 
 esp_err_t vigilant_init(VigilantConfig VgConfig);

--- a/components/vigilant_engine/include/vigilant.h
+++ b/components/vigilant_engine/include/vigilant.h
@@ -28,8 +28,14 @@ typedef struct {
     char ip_ap[16];          // current AP IPv4 (or "0.0.0.0")
 } VigilantInfo;
 
+typedef struct {
+    bool enabled;
+    VigilantI2CDevice devices[8]; // fixed-size array for simplicity; adjust as needed
+} VigilantI2cInfo;
+
 esp_err_t vigilant_init(VigilantConfig VgConfig);
 esp_err_t vigilant_get_info(VigilantInfo *info);
+esp_err_t vigilant_get_i2cinfo(VigilantI2cInfo *info);
 esp_err_t vigilant_i2c_add_device(VigilantI2CDevice *device);
 esp_err_t vigilant_i2c_remove_device(VigilantI2CDevice *device);
 esp_err_t vigilant_i2c_set_reg8(VigilantI2CDevice *device, uint8_t reg, uint8_t value);

--- a/components/vigilant_engine/include/vigilant.h
+++ b/components/vigilant_engine/include/vigilant.h
@@ -30,6 +30,10 @@ typedef struct {
 
 typedef struct {
     bool enabled;
+    uint8_t sda_io;
+    uint8_t scl_io;
+    uint32_t frequency_hz;
+    uint8_t device_count;
     VigilantI2CDevice devices[8]; // fixed-size array for simplicity; adjust as needed
 } VigilantI2cInfo;
 

--- a/components/vigilant_engine/include/websocket.h
+++ b/components/vigilant_engine/include/websocket.h
@@ -17,6 +17,9 @@ void websocket_init_log_capture(void);
 // to connected clients.
 esp_err_t websocket_register_handlers(httpd_handle_t server);
 
+// Removes the socket from the websocket client table when HTTPD closes it.
+void websocket_client_closed(int fd);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/vigilant_engine/src/http_server.c
+++ b/components/vigilant_engine/src/http_server.c
@@ -30,7 +30,7 @@ static const char *TAG = "http_server";
 static httpd_handle_t s_server = NULL;   // unser globaler Server-Handle
 
 #if defined(CONFIG_LWIP_MAX_SOCKETS) && CONFIG_LWIP_MAX_SOCKETS >= 13
-#define VE_HTTPD_MAX_OPEN_SOCKETS 10
+#define VE_HTTPD_MAX_OPEN_SOCKETS 10 // Increase max open sockets if lwip socket amount is increased
 #else
 #define VE_HTTPD_MAX_OPEN_SOCKETS 7
 #endif

--- a/components/vigilant_engine/src/http_server.c
+++ b/components/vigilant_engine/src/http_server.c
@@ -241,17 +241,56 @@ static esp_err_t i2cinfo_get_handler(httpd_req_t *req)
     }
 
     httpd_resp_set_type(req, "application/json");
-    char payload[256];
-    int written = snprintf(payload, sizeof(payload),
-        "{\"enabled\":\"true\"}",
-        );
+    char payload[2048];
+    size_t offset = 0;
+    int written = snprintf(
+        payload + offset,
+        sizeof(payload) - offset,
+        "{\"enabled\":%s,\"sda_io\":%u,\"scl_io\":%u,\"frequency_hz\":%" PRIu32 ",\"device_count\":%u,\"devices\":[",
+        info.enabled ? "true" : "false",
+        (unsigned int)info.sda_io,
+        (unsigned int)info.scl_io,
+        info.frequency_hz,
+        (unsigned int)info.device_count
+    );
 
-    if (written < 0 || written >= (int)sizeof(payload)) {
+    if (written < 0 || written >= (int)(sizeof(payload) - offset)) {
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Info too large");
         return ESP_FAIL;
     }
+    offset += (size_t)written;
 
-    httpd_resp_send(req, payload, written);
+    for (uint8_t i = 0; i < info.device_count; ++i) {
+        const VigilantI2CDevice *device = &info.devices[i];
+        written = snprintf(
+            payload + offset,
+            sizeof(payload) - offset,
+            "%s{\"name\":\"I2C Device 0x%02X\",\"address\":%u,\"address_hex\":\"0x%02X\",\"whoami_reg\":%u,\"whoami_reg_hex\":\"0x%02X\",\"expected_whoami\":%u,\"expected_whoami_hex\":\"0x%02X\"}",
+            i == 0 ? "" : ",",
+            (unsigned int)device->address,
+            (unsigned int)device->address,
+            (unsigned int)device->address,
+            (unsigned int)device->whoami_reg,
+            (unsigned int)device->whoami_reg,
+            (unsigned int)device->expected_whoami,
+            (unsigned int)device->expected_whoami
+        );
+
+        if (written < 0 || written >= (int)(sizeof(payload) - offset)) {
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Info too large");
+            return ESP_FAIL;
+        }
+        offset += (size_t)written;
+    }
+
+    written = snprintf(payload + offset, sizeof(payload) - offset, "]}");
+    if (written < 0 || written >= (int)(sizeof(payload) - offset)) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Info too large");
+        return ESP_FAIL;
+    }
+    offset += (size_t)written;
+
+    httpd_resp_send(req, payload, (ssize_t)offset);
     return ESP_OK;
 }
 

--- a/components/vigilant_engine/src/http_server.c
+++ b/components/vigilant_engine/src/http_server.c
@@ -231,6 +231,39 @@ static const httpd_uri_t info_uri = {
     .user_ctx  = NULL,
 };
 
+static esp_err_t i2cinfo_get_handler(httpd_req_t *req)
+{
+    VigilantI2cInfo info = {0};
+    esp_err_t err = vigilant_get_i2cinfo(&info);
+    if (err != ESP_OK) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Failed to fetch i2c info");
+        return err;
+    }
+
+    httpd_resp_set_type(req, "application/json");
+    char payload[256];
+    int written = snprintf(payload, sizeof(payload),
+        "{\"enabled\":\"true\"}",
+        );
+
+    if (written < 0 || written >= (int)sizeof(payload)) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Info too large");
+        return ESP_FAIL;
+    }
+
+    httpd_resp_send(req, payload, written);
+    return ESP_OK;
+}
+
+static const httpd_uri_t i2cinfo_uri = {
+    .uri       = "/i2cinfo",
+    .method    = HTTP_GET,
+    .handler   = i2cinfo_get_handler,
+    .user_ctx  = NULL,
+};
+
+
+
 esp_err_t http_404_error_handler(httpd_req_t *req, httpd_err_code_t err)
 {
     if (strcmp("/hello", req->uri) == 0) {
@@ -294,6 +327,7 @@ static httpd_handle_t start_webserver_internal(void)
         httpd_register_uri_handler(server, &ctrl);
         httpd_register_uri_handler(server, &any);
         httpd_register_uri_handler(server, &info_uri);
+        httpd_register_uri_handler(server, &i2cinfo_uri);
         websocket_register_handlers(server);
 
         // OTA-Handler registrieren

--- a/components/vigilant_engine/src/http_server.c
+++ b/components/vigilant_engine/src/http_server.c
@@ -401,7 +401,6 @@ static const httpd_uri_t ctrl = {
 
 static void close_socket_with_ws_cleanup(httpd_handle_t hd, int sockfd)
 {
-    (void)hd;
     websocket_client_closed(sockfd);
     close(sockfd);
 }

--- a/components/vigilant_engine/src/http_server.c
+++ b/components/vigilant_engine/src/http_server.c
@@ -14,6 +14,7 @@
 #include "esp_event.h"
 #include "esp_netif.h"
 #include "esp_tls_crypto.h"
+#include "sdkconfig.h"
 
 #include "ota_http.h"
 #include "vigilant.h"
@@ -27,6 +28,12 @@
 static const char *TAG = "http_server";
 
 static httpd_handle_t s_server = NULL;   // unser globaler Server-Handle
+
+#if defined(CONFIG_LWIP_MAX_SOCKETS) && CONFIG_LWIP_MAX_SOCKETS >= 13
+#define VE_HTTPD_MAX_OPEN_SOCKETS 10
+#else
+#define VE_HTTPD_MAX_OPEN_SOCKETS 7
+#endif
 
 static int hex_nibble(char c)
 {
@@ -392,14 +399,29 @@ static const httpd_uri_t ctrl = {
     .user_ctx  = NULL
 };
 
+static void close_socket_with_ws_cleanup(httpd_handle_t hd, int sockfd)
+{
+    (void)hd;
+    websocket_client_closed(sockfd);
+    close(sockfd);
+}
+
 static httpd_handle_t start_webserver_internal(void)
 {
     httpd_handle_t server = NULL;
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.max_uri_handlers = 32; // Fixes issue #28: ota_http: Failed to register Vigilant Dashboard GET handler (ESP_ERR_HTTPD_HANDLERS_FULL)
+    config.max_open_sockets = VE_HTTPD_MAX_OPEN_SOCKETS;
+    config.backlog_conn = 8;
     config.lru_purge_enable = true;
+    config.keep_alive_enable = true;
+    config.keep_alive_idle = 30;
+    config.keep_alive_interval = 5;
+    config.keep_alive_count = 3;
+    config.close_fn = close_socket_with_ws_cleanup;
 
-    ESP_LOGI(TAG, "Starting server on port: '%d'", config.server_port);
+    ESP_LOGI(TAG, "Starting server on port: '%d' with %d open sockets",
+             config.server_port, config.max_open_sockets);
     if (httpd_start(&server, &config) == ESP_OK) {
         ESP_LOGI(TAG, "Registering URI handlers");
         httpd_register_uri_handler(server, &hello);
@@ -443,17 +465,6 @@ esp_err_t http_server_stop(void)
 }
 
 #if !CONFIG_IDF_TARGET_LINUX
-static void disconnect_handler(void* arg, esp_event_base_t event_base,
-                               int32_t event_id, void* event_data)
-{
-    (void)arg;
-    (void)event_base;
-    (void)event_id;
-    (void)event_data;
-
-    http_server_stop();
-}
-
 static void connect_handler(void* arg, esp_event_base_t event_base,
                             int32_t event_id, void* event_data)
 {

--- a/components/vigilant_engine/src/http_server.c
+++ b/components/vigilant_engine/src/http_server.c
@@ -241,30 +241,40 @@ static esp_err_t i2cinfo_get_handler(httpd_req_t *req)
     }
 
     httpd_resp_set_type(req, "application/json");
-    char payload[2048];
+    size_t payload_capacity = 256
+        + ((size_t)info.added_device_count * 160)
+        + ((size_t)info.detected_device_count * 96);
+    char *payload = malloc(payload_capacity);
+    if (!payload) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "No memory for i2c info");
+        return ESP_ERR_NO_MEM;
+    }
+
     size_t offset = 0;
     int written = snprintf(
         payload + offset,
-        sizeof(payload) - offset,
-        "{\"enabled\":%s,\"sda_io\":%u,\"scl_io\":%u,\"frequency_hz\":%" PRIu32 ",\"device_count\":%u,\"devices\":[",
+        payload_capacity - offset,
+        "{\"enabled\":%s,\"sda_io\":%u,\"scl_io\":%u,\"frequency_hz\":%" PRIu32 ",\"added_device_count\":%u,\"detected_device_count\":%u,\"added_devices\":[",
         info.enabled ? "true" : "false",
         (unsigned int)info.sda_io,
         (unsigned int)info.scl_io,
         info.frequency_hz,
-        (unsigned int)info.device_count
+        (unsigned int)info.added_device_count,
+        (unsigned int)info.detected_device_count
     );
 
-    if (written < 0 || written >= (int)(sizeof(payload) - offset)) {
+    if (written < 0 || written >= (int)(payload_capacity - offset)) {
+        free(payload);
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Info too large");
         return ESP_FAIL;
     }
     offset += (size_t)written;
 
-    for (uint8_t i = 0; i < info.device_count; ++i) {
-        const VigilantI2CDevice *device = &info.devices[i];
+    for (uint8_t i = 0; i < info.added_device_count; ++i) {
+        const VigilantI2CDevice *device = &info.added_devices[i];
         written = snprintf(
             payload + offset,
-            sizeof(payload) - offset,
+            payload_capacity - offset,
             "%s{\"name\":\"I2C Device 0x%02X\",\"address\":%u,\"address_hex\":\"0x%02X\",\"whoami_reg\":%u,\"whoami_reg_hex\":\"0x%02X\",\"expected_whoami\":%u,\"expected_whoami_hex\":\"0x%02X\"}",
             i == 0 ? "" : ",",
             (unsigned int)device->address,
@@ -276,21 +286,52 @@ static esp_err_t i2cinfo_get_handler(httpd_req_t *req)
             (unsigned int)device->expected_whoami
         );
 
-        if (written < 0 || written >= (int)(sizeof(payload) - offset)) {
+        if (written < 0 || written >= (int)(payload_capacity - offset)) {
+            free(payload);
             httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Info too large");
             return ESP_FAIL;
         }
         offset += (size_t)written;
     }
 
-    written = snprintf(payload + offset, sizeof(payload) - offset, "]}");
-    if (written < 0 || written >= (int)(sizeof(payload) - offset)) {
+    written = snprintf(payload + offset, payload_capacity - offset, "],\"detected_devices\":[");
+    if (written < 0 || written >= (int)(payload_capacity - offset)) {
+        free(payload);
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Info too large");
+        return ESP_FAIL;
+    }
+    offset += (size_t)written;
+
+    for (uint8_t i = 0; i < info.detected_device_count; ++i) {
+        uint8_t address = info.detected_devices[i];
+        written = snprintf(
+            payload + offset,
+            payload_capacity - offset,
+            "%s{\"name\":\"Detected I2C Device 0x%02X\",\"address\":%u,\"address_hex\":\"0x%02X\"}",
+            i == 0 ? "" : ",",
+            (unsigned int)address,
+            (unsigned int)address,
+            (unsigned int)address
+        );
+
+        if (written < 0 || written >= (int)(payload_capacity - offset)) {
+            free(payload);
+            httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Info too large");
+            return ESP_FAIL;
+        }
+        offset += (size_t)written;
+    }
+
+    written = snprintf(payload + offset, payload_capacity - offset, "]}");
+    if (written < 0 || written >= (int)(payload_capacity - offset)) {
+        free(payload);
         httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR, "Info too large");
         return ESP_FAIL;
     }
     offset += (size_t)written;
 
     httpd_resp_send(req, payload, (ssize_t)offset);
+    free(payload);
     return ESP_OK;
 }
 

--- a/components/vigilant_engine/src/http_server.c
+++ b/components/vigilant_engine/src/http_server.c
@@ -241,8 +241,8 @@ static esp_err_t i2cinfo_get_handler(httpd_req_t *req)
     }
 
     httpd_resp_set_type(req, "application/json");
-    size_t payload_capacity = 256
-        + ((size_t)info.added_device_count * 160)
+    size_t payload_capacity = 256 // Calculates a size for the json object, for malloc later
+        + ((size_t)info.added_device_count * 160) // Added devices contain more information in the json than detected devices.
         + ((size_t)info.detected_device_count * 96);
     char *payload = malloc(payload_capacity);
     if (!payload) {

--- a/components/vigilant_engine/src/i2c.c
+++ b/components/vigilant_engine/src/i2c.c
@@ -16,9 +16,96 @@
 #define I2C_TIMEOUT_MS      50
 
 static const char *TAG = "ve_i2c";
-
-
 static i2c_master_bus_handle_t s_i2c_bus = NULL;
+static uint8_t s_detected_i2c_addresses[16] = {0};
+static size_t s_detected_i2c_count = 0;
+
+static esp_err_t i2c_scan_devices(uint8_t *addresses, size_t max_addresses, size_t *count, bool log_results)
+{
+    if (!s_i2c_bus) {
+        return ESP_ERR_INVALID_STATE;
+    }
+    if (!count) {
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    char line[128];
+    size_t found = 0;
+    size_t stored = 0;
+
+    if (log_results) {
+        ESP_LOGI(TAG, "I2C bus scan on SDA=%d SCL=%d", I2C_SDA_IO, I2C_SCL_IO);
+
+        strcpy(line, "    ");
+        for (int i = 0; i < 16; i++) {
+            char tmp[4];
+            snprintf(tmp, sizeof(tmp), "%02X ", i);
+            strncat(line, tmp, sizeof(line) - strlen(line) - 1);
+        }
+        ESP_LOGI(TAG, "%s", line);
+    }
+
+    for (int high = 0; high < 8; high++) {
+        if (log_results) {
+            snprintf(line, sizeof(line), "%02X: ", high << 4);
+        }
+
+        for (int low = 0; low < 16; low++) {
+            uint8_t addr = (high << 4) | low;
+            char cell[4] = "   ";
+
+            if (addr >= 0x03 && addr <= 0x77) {
+                esp_err_t err = i2c_master_probe(s_i2c_bus, addr, I2C_TIMEOUT_MS);
+                if (err == ESP_OK) {
+                    if (addresses && stored < max_addresses) {
+                        addresses[stored++] = addr;
+                    }
+                    found++;
+                    if (log_results) {
+                        snprintf(cell, sizeof(cell), "%02X ", addr);
+                    }
+                } else if (log_results) {
+                    snprintf(cell, sizeof(cell), "-- ");
+                }
+            }
+
+            if (log_results) {
+                strncat(line, cell, sizeof(line) - strlen(line) - 1);
+            }
+        }
+
+        if (log_results) {
+            ESP_LOGI(TAG, "%s", line);
+        }
+    }
+
+    if (log_results) {
+        ESP_LOGI(TAG, "Scan complete, found %u device(s)", (unsigned int)found);
+        if (stored < found) {
+            ESP_LOGW(TAG, "Detected device list truncated to %u entrie(s)", (unsigned int)stored);
+        }
+    }
+
+    *count = stored;
+    return ESP_OK;
+}
+
+static esp_err_t i2c_refresh_detected_devices(bool log_results)
+{
+    size_t detected_count = 0;
+    esp_err_t err = i2c_scan_devices(
+        s_detected_i2c_addresses,
+        sizeof(s_detected_i2c_addresses) / sizeof(s_detected_i2c_addresses[0]),
+        &detected_count,
+        log_results
+    );
+    if (err != ESP_OK) {
+        return err;
+    }
+
+    s_detected_i2c_count = detected_count;
+    return ESP_OK;
+}
 
 esp_err_t i2c_init(void)
 {
@@ -46,45 +133,10 @@ esp_err_t i2c_init(void)
     }
 
     ESP_LOGI(TAG, "Bus initialized successfully");
-    ESP_LOGI(TAG, "I2C bus scan on SDA=%d SCL=%d", I2C_SDA_IO, I2C_SCL_IO);
-
-    char line[128];
-    int found = 0;
-
-    strcpy(line, "    ");
-    for (int i = 0; i < 16; i++) {
-        char tmp[4];
-        snprintf(tmp, sizeof(tmp), "%02X ", i);
-        strncat(line, tmp, sizeof(line) - strlen(line) - 1);
+    err = i2c_refresh_detected_devices(true);
+    if (err != ESP_OK) {
+        ESP_LOGW(TAG, "Initial I2C scan failed: %s", esp_err_to_name(err));
     }
-    ESP_LOGI(TAG, "%s", line);
-
-    for (int high = 0; high < 8; high++) {
-        snprintf(line, sizeof(line), "%02X: ", high << 4);
-
-        for (int low = 0; low < 16; low++) {
-            uint8_t addr = (high << 4) | low;
-            char cell[4];
-
-            if (addr < 0x03 || addr > 0x77) {
-                snprintf(cell, sizeof(cell), "   ");
-            } else {
-                err = i2c_master_probe(s_i2c_bus, addr, I2C_TIMEOUT_MS);
-                if (err == ESP_OK) {
-                    snprintf(cell, sizeof(cell), "%02X ", addr);
-                    found++;
-                } else {
-                    snprintf(cell, sizeof(cell), "-- ");
-                }
-            }
-
-            strncat(line, cell, sizeof(line) - strlen(line) - 1);
-        }
-
-        ESP_LOGI(TAG, "%s", line);
-    }
-
-    ESP_LOGI(TAG, "Scan complete, found %d device(s)", found);
 
     return ESP_OK;
 }
@@ -193,6 +245,28 @@ esp_err_t i2c_whoami_check(VigilantI2CDevice *device)
     return ESP_OK;
 }
 
+esp_err_t i2c_get_detected_devices(uint8_t *addresses, size_t max_addresses, size_t *count)
+{
+    if (!count) {
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (!s_i2c_bus) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
+    size_t copied_count = s_detected_i2c_count;
+    if (copied_count > max_addresses) {
+        copied_count = max_addresses;
+    }
+
+    if (addresses && copied_count > 0) {
+        memcpy(addresses, s_detected_i2c_addresses, copied_count * sizeof(s_detected_i2c_addresses[0]));
+    }
+
+    *count = copied_count;
+    return ESP_OK;
+}
+
 void i2c_deinit(void)
 {
     if (s_i2c_bus) {
@@ -203,5 +277,7 @@ void i2c_deinit(void)
         }
 
         s_i2c_bus = NULL;
+        memset(s_detected_i2c_addresses, 0, sizeof(s_detected_i2c_addresses));
+        s_detected_i2c_count = 0;
     }
 }

--- a/components/vigilant_engine/src/vigilant.c
+++ b/components/vigilant_engine/src/vigilant.c
@@ -24,11 +24,14 @@
 #include "websocket.h"
 
 static const char *TAG = "vigilant";
+static const size_t MAX_I2C_INFO_DEVICES = 8;
 
 static esp_netif_t *s_netif_sta = NULL;
 static esp_netif_t *s_netif_ap  = NULL;
 static VigilantConfig s_cfg = {0};
 static TimerHandle_t sta_reconnect_timer;
+static VigilantI2CDevice s_i2c_devices[8] = {0};
+static size_t s_i2c_device_count = 0;
 
 static wifi_config_t sta_cfg = {
     .sta = {
@@ -49,6 +52,59 @@ static wifi_config_t ap_cfg = {
         .authmode = WIFI_AUTH_WPA2_PSK 
     }
 };
+
+static int registered_i2c_device_index(const VigilantI2CDevice *device)
+{
+    if (!device) {
+        return -1;
+    }
+
+    for (size_t i = 0; i < s_i2c_device_count; ++i) {
+        if (s_i2c_devices[i].address == device->address &&
+            s_i2c_devices[i].whoami_reg == device->whoami_reg &&
+            s_i2c_devices[i].expected_whoami == device->expected_whoami) {
+            return (int)i;
+        }
+    }
+
+    return -1;
+}
+
+static void sync_registered_i2c_device(const VigilantI2CDevice *device)
+{
+    if (!device) {
+        return;
+    }
+
+    int existing_index = registered_i2c_device_index(device);
+    if (existing_index >= 0) {
+        s_i2c_devices[existing_index] = *device;
+        return;
+    }
+
+    if (s_i2c_device_count >= MAX_I2C_INFO_DEVICES) {
+        ESP_LOGW(TAG, "I2C device registry full; device 0x%02X will not be exposed via /i2cinfo",
+                 (unsigned int)device->address);
+        return;
+    }
+
+    s_i2c_devices[s_i2c_device_count++] = *device;
+}
+
+static void remove_registered_i2c_device(const VigilantI2CDevice *device)
+{
+    int existing_index = registered_i2c_device_index(device);
+    if (existing_index < 0) {
+        return;
+    }
+
+    for (size_t i = (size_t)existing_index + 1; i < s_i2c_device_count; ++i) {
+        s_i2c_devices[i - 1] = s_i2c_devices[i];
+    }
+
+    s_i2c_device_count--;
+    memset(&s_i2c_devices[s_i2c_device_count], 0, sizeof(s_i2c_devices[0]));
+}
 
 static void ap_cfg_fixup(wifi_config_t *cfg)
 {
@@ -269,20 +325,32 @@ esp_err_t vigilant_get_info(VigilantInfo *info)
 
 esp_err_t vigilant_get_i2cinfo(VigilantI2cInfo *info)
 {
-    info = malloc(sizeof(VigilantI2cInfo));
     if (!info) {
-        return ESP_ERR_NO_MEM;
+        return ESP_ERR_INVALID_ARG;
     }
-    info = memset(info, 0, sizeof(VigilantI2cInfo));
+
+    memset(info, 0, sizeof(*info));
     info->enabled = CONFIG_VE_ENABLE_I2C;
-    
+
+#if CONFIG_VE_ENABLE_I2C
+    info->sda_io = CONFIG_VE_I2C_SDA_IO;
+    info->scl_io = CONFIG_VE_I2C_SCL_IO;
+    info->frequency_hz = CONFIG_VE_I2C_FREQ_HZ;
+    info->device_count = (uint8_t)s_i2c_device_count;
+    memcpy(info->devices, s_i2c_devices, sizeof(s_i2c_devices[0]) * s_i2c_device_count);
+#endif
+
     return ESP_OK;
 }
 
 esp_err_t vigilant_i2c_add_device(VigilantI2CDevice *device)
 {
 #if CONFIG_VE_ENABLE_I2C
-    return i2c_add_device(device);
+    esp_err_t err = i2c_add_device(device);
+    if (err == ESP_OK) {
+        sync_registered_i2c_device(device);
+    }
+    return err;
 #else
     (void)device;
     return ESP_ERR_NOT_SUPPORTED;
@@ -292,7 +360,11 @@ esp_err_t vigilant_i2c_add_device(VigilantI2CDevice *device)
 esp_err_t vigilant_i2c_remove_device(VigilantI2CDevice *device)
 {
 #if CONFIG_VE_ENABLE_I2C
-    return i2c_remove_device(device);
+    esp_err_t err = i2c_remove_device(device);
+    if (err == ESP_OK) {
+        remove_registered_i2c_device(device);
+    }
+    return err;
 #else
     (void)device;
     return ESP_ERR_NOT_SUPPORTED;

--- a/components/vigilant_engine/src/vigilant.c
+++ b/components/vigilant_engine/src/vigilant.c
@@ -336,8 +336,20 @@ esp_err_t vigilant_get_i2cinfo(VigilantI2cInfo *info)
     info->sda_io = CONFIG_VE_I2C_SDA_IO;
     info->scl_io = CONFIG_VE_I2C_SCL_IO;
     info->frequency_hz = CONFIG_VE_I2C_FREQ_HZ;
-    info->device_count = (uint8_t)s_i2c_device_count;
-    memcpy(info->devices, s_i2c_devices, sizeof(s_i2c_devices[0]) * s_i2c_device_count);
+    info->added_device_count = (uint8_t)s_i2c_device_count;
+    memcpy(info->added_devices, s_i2c_devices, sizeof(s_i2c_devices[0]) * s_i2c_device_count);
+
+    size_t detected_count = 0;
+    esp_err_t detected_err = i2c_get_detected_devices(
+        info->detected_devices,
+        sizeof(info->detected_devices) / sizeof(info->detected_devices[0]),
+        &detected_count
+    );
+    if (detected_err != ESP_OK) {
+        return detected_err;
+    }
+
+    info->detected_device_count = (uint8_t)detected_count;
 #endif
 
     return ESP_OK;

--- a/components/vigilant_engine/src/vigilant.c
+++ b/components/vigilant_engine/src/vigilant.c
@@ -206,6 +206,7 @@ static esp_err_t wifi_apply_mode(NW_MODE mode,
     ESP_ERROR_CHECK(esp_wifi_start());
 
     if (mode == NW_MODE_STA || mode == NW_MODE_APSTA) {
+        ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
         ESP_ERROR_CHECK(esp_wifi_connect()); // AP-only: NICHT connecten
     }
 

--- a/components/vigilant_engine/src/vigilant.c
+++ b/components/vigilant_engine/src/vigilant.c
@@ -24,14 +24,18 @@
 #include "websocket.h"
 
 static const char *TAG = "vigilant";
+#if CONFIG_VE_ENABLE_I2C
 static const size_t MAX_I2C_INFO_DEVICES = 8;
+#endif
 
 static esp_netif_t *s_netif_sta = NULL;
 static esp_netif_t *s_netif_ap  = NULL;
 static VigilantConfig s_cfg = {0};
 static TimerHandle_t sta_reconnect_timer;
+#if CONFIG_VE_ENABLE_I2C
 static VigilantI2CDevice s_i2c_devices[8] = {0};
 static size_t s_i2c_device_count = 0;
+#endif
 
 static wifi_config_t sta_cfg = {
     .sta = {
@@ -53,6 +57,7 @@ static wifi_config_t ap_cfg = {
     }
 };
 
+#if CONFIG_VE_ENABLE_I2C
 static int registered_i2c_device_index(const VigilantI2CDevice *device)
 {
     if (!device) {
@@ -105,6 +110,7 @@ static void remove_registered_i2c_device(const VigilantI2CDevice *device)
     s_i2c_device_count--;
     memset(&s_i2c_devices[s_i2c_device_count], 0, sizeof(s_i2c_devices[0]));
 }
+#endif
 
 static void ap_cfg_fixup(wifi_config_t *cfg)
 {
@@ -330,9 +336,9 @@ esp_err_t vigilant_get_i2cinfo(VigilantI2cInfo *info)
     }
 
     memset(info, 0, sizeof(*info));
-    info->enabled = CONFIG_VE_ENABLE_I2C;
 
 #if CONFIG_VE_ENABLE_I2C
+    info->enabled = true;
     info->sda_io = CONFIG_VE_I2C_SDA_IO;
     info->scl_io = CONFIG_VE_I2C_SCL_IO;
     info->frequency_hz = CONFIG_VE_I2C_FREQ_HZ;
@@ -350,6 +356,8 @@ esp_err_t vigilant_get_i2cinfo(VigilantI2cInfo *info)
     }
 
     info->detected_device_count = (uint8_t)detected_count;
+#else
+    info->enabled = false;
 #endif
 
     return ESP_OK;

--- a/components/vigilant_engine/src/vigilant.c
+++ b/components/vigilant_engine/src/vigilant.c
@@ -267,6 +267,18 @@ esp_err_t vigilant_get_info(VigilantInfo *info)
     return ESP_OK;
 }
 
+esp_err_t vigilant_get_i2cinfo(VigilantI2cInfo *info)
+{
+    info = malloc(sizeof(VigilantI2cInfo));
+    if (!info) {
+        return ESP_ERR_NO_MEM;
+    }
+    info = memset(info, 0, sizeof(VigilantI2cInfo));
+    info->enabled = CONFIG_VE_ENABLE_I2C;
+    
+    return ESP_OK;
+}
+
 esp_err_t vigilant_i2c_add_device(VigilantI2CDevice *device)
 {
 #if CONFIG_VE_ENABLE_I2C

--- a/components/vigilant_engine/src/websocket.c
+++ b/components/vigilant_engine/src/websocket.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdarg.h>
 #include <stdio.h>
 
@@ -17,15 +18,19 @@ static const char *TAG_WS = "ws";
 #define LOG_HISTORY_LINES 200
 #define LOG_LINE_MAX      256
 #define MAX_WS_CLIENTS    8
+#define MAX_PENDING_SENDS_PER_CLIENT 3
 
 typedef struct {
     int fd;
     bool active;
+    uint32_t generation;
+    uint8_t pending_sends;
 } ws_client_t;
 
 typedef struct {
     httpd_handle_t hd;
     int fd;
+    uint32_t generation;
     char *payload;
     size_t len;
 } ws_send_arg_t;
@@ -37,6 +42,7 @@ static char s_log_lines[LOG_HISTORY_LINES][LOG_LINE_MAX];
 static size_t s_log_head = 0;   // next write position
 static size_t s_log_count = 0;  // number of valid lines
 static SemaphoreHandle_t s_ws_mutex = NULL;
+static uint32_t s_next_generation = 1;
 
 static vprintf_like_t s_orig_vprintf = NULL;
 
@@ -53,6 +59,15 @@ static bool ws_client_is_connected(int fd)
     return httpd_ws_get_fd_info(s_server_handle, fd) == HTTPD_WS_CLIENT_WEBSOCKET;
 }
 
+static uint32_t next_generation(void)
+{
+    uint32_t generation = s_next_generation++;
+    if (s_next_generation == 0) {
+        s_next_generation = 1;
+    }
+    return generation;
+}
+
 static void ensure_mutex(void)
 {
     if (!s_ws_mutex) {
@@ -60,16 +75,19 @@ static void ensure_mutex(void)
     }
 }
 
-static void ws_clients_add(int fd)
+static uint32_t ws_clients_add(int fd)
 {
     ensure_mutex();
-    if (!s_ws_mutex) return;
+    if (!s_ws_mutex) return 0;
 
     xSemaphoreTake(s_ws_mutex, portMAX_DELAY);
     for (int i = 0; i < MAX_WS_CLIENTS; ++i) {
         if (s_clients[i].active && s_clients[i].fd == fd) {
+            s_clients[i].generation = next_generation();
+            s_clients[i].pending_sends = 0;
+            uint32_t generation = s_clients[i].generation;
             xSemaphoreGive(s_ws_mutex);
-            return;
+            return generation;
         }
     }
 
@@ -77,26 +95,111 @@ static void ws_clients_add(int fd)
         if (!s_clients[i].active) {
             s_clients[i].fd = fd;
             s_clients[i].active = true;
+            s_clients[i].generation = next_generation();
+            s_clients[i].pending_sends = 0;
+            uint32_t generation = s_clients[i].generation;
             xSemaphoreGive(s_ws_mutex);
-            return;
+            return generation;
         }
     }
     xSemaphoreGive(s_ws_mutex);
 
     ESP_LOGW(TAG_WS, "WS client table full, dropping fd=%d", fd);
+    return 0;
+}
+
+static bool ws_clients_remove_generation(int fd, uint32_t generation)
+{
+    if (!s_ws_mutex) return false;
+    bool removed = false;
+    xSemaphoreTake(s_ws_mutex, portMAX_DELAY);
+    for (int i = 0; i < MAX_WS_CLIENTS; ++i) {
+        if (s_clients[i].active && s_clients[i].fd == fd &&
+            (generation == 0 || s_clients[i].generation == generation)) {
+            s_clients[i].active = false;
+            s_clients[i].fd = -1;
+            s_clients[i].generation = 0;
+            s_clients[i].pending_sends = 0;
+            removed = true;
+        }
+    }
+    xSemaphoreGive(s_ws_mutex);
+    return removed;
 }
 
 static void ws_clients_remove(int fd)
 {
-    if (!s_ws_mutex) return;
+    (void)ws_clients_remove_generation(fd, 0);
+}
+
+static bool ws_clients_mark_send_queued(int fd, uint32_t *generation)
+{
+    ensure_mutex();
+    if (!s_ws_mutex) return false;
+
+    bool queued = false;
     xSemaphoreTake(s_ws_mutex, portMAX_DELAY);
     for (int i = 0; i < MAX_WS_CLIENTS; ++i) {
         if (s_clients[i].active && s_clients[i].fd == fd) {
-            s_clients[i].active = false;
-            s_clients[i].fd = -1;
+            if (s_clients[i].pending_sends < MAX_PENDING_SENDS_PER_CLIENT) {
+                s_clients[i].pending_sends++;
+                *generation = s_clients[i].generation;
+                queued = true;
+            }
+            break;
         }
     }
     xSemaphoreGive(s_ws_mutex);
+    return queued;
+}
+
+static void ws_clients_mark_send_done(int fd, uint32_t generation)
+{
+    if (!s_ws_mutex) return;
+
+    xSemaphoreTake(s_ws_mutex, portMAX_DELAY);
+    for (int i = 0; i < MAX_WS_CLIENTS; ++i) {
+        if (s_clients[i].active && s_clients[i].fd == fd &&
+            s_clients[i].generation == generation) {
+            if (s_clients[i].pending_sends > 0) {
+                s_clients[i].pending_sends--;
+            }
+            break;
+        }
+    }
+    xSemaphoreGive(s_ws_mutex);
+}
+
+static bool ws_client_generation_is_current(int fd, uint32_t generation)
+{
+    if (!s_ws_mutex) return false;
+
+    bool current = false;
+    xSemaphoreTake(s_ws_mutex, portMAX_DELAY);
+    for (int i = 0; i < MAX_WS_CLIENTS; ++i) {
+        if (s_clients[i].active && s_clients[i].fd == fd &&
+            s_clients[i].generation == generation) {
+            current = true;
+            break;
+        }
+    }
+    xSemaphoreGive(s_ws_mutex);
+    return current;
+}
+
+static void ws_trigger_close_if_current(int fd, uint32_t generation)
+{
+    if (ws_clients_remove_generation(fd, generation) && s_server_handle) {
+        httpd_sess_trigger_close(s_server_handle, fd);
+    }
+}
+
+static bool should_stream_log_line(const char *line)
+{
+    // Avoid feeding HTTPD/WebSocket transport errors back into the WebSocket
+    // that just failed. They still print on UART and remain in the history.
+    return !strstr(line, " httpd_txrx:") &&
+           !strstr(line, " httpd_ws:");
 }
 
 static void append_log_line(const char *line)
@@ -120,8 +223,10 @@ static void ws_send_text_async(void *arg)
     ws_send_arg_t *a = (ws_send_arg_t *)arg;
     if (!a) return;
 
-    if (!ws_client_is_connected(a->fd)) {
-        ws_clients_remove(a->fd);
+    if (!ws_client_generation_is_current(a->fd, a->generation) ||
+        !ws_client_is_connected(a->fd)) {
+        ws_clients_mark_send_done(a->fd, a->generation);
+        ws_trigger_close_if_current(a->fd, a->generation);
         free(a->payload);
         free(a);
         return;
@@ -136,8 +241,9 @@ static void ws_send_text_async(void *arg)
     };
 
     esp_err_t ret = httpd_ws_send_frame_async(a->hd, a->fd, &frame);
+    ws_clients_mark_send_done(a->fd, a->generation);
     if (ret != ESP_OK) {
-        ws_clients_remove(a->fd);
+        ws_trigger_close_if_current(a->fd, a->generation);
     }
 
     free(a->payload);
@@ -150,16 +256,23 @@ static esp_err_t ws_queue_send_text(int fd, const char *text)
         return ESP_ERR_INVALID_STATE;
     }
 
+    uint32_t generation = 0;
+    if (!ws_clients_mark_send_queued(fd, &generation)) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
     ws_send_arg_t *arg = (ws_send_arg_t *)malloc(sizeof(ws_send_arg_t));
     char *dup = strdup(text);
     if (!arg || !dup) {
         free(arg);
         free(dup);
+        ws_clients_mark_send_done(fd, generation);
         return ESP_ERR_NO_MEM;
     }
 
     arg->hd = s_server_handle;
     arg->fd = fd;
+    arg->generation = generation;
     arg->payload = dup;
     arg->len = strlen(dup);
 
@@ -167,7 +280,7 @@ static esp_err_t ws_queue_send_text(int fd, const char *text)
     if (ret != ESP_OK) {
         free(arg->payload);
         free(arg);
-        ws_clients_remove(fd);
+        ws_clients_mark_send_done(fd, generation);
     }
     return ret;
 }
@@ -222,7 +335,9 @@ static int websocket_log_vprintf(const char *fmt, va_list ap)
     }
 
     append_log_line(line);
-    broadcast_log_line(line);
+    if (should_stream_log_line(line)) {
+        broadcast_log_line(line);
+    }
 
     if (s_orig_vprintf) {
         return s_orig_vprintf(fmt, ap);
@@ -283,7 +398,11 @@ static esp_err_t websocket_handler(httpd_req_t *req)
 
     // Handshake call
     if (req->method == HTTP_GET) {
-        ws_clients_add(fd);
+        uint32_t generation = ws_clients_add(fd);
+        if (generation == 0) {
+            httpd_sess_trigger_close(req->handle, fd);
+            return ESP_FAIL;
+        }
         send_log_history(fd);
         ESP_LOGI(TAG_WS, "WebSocket client connected: fd=%d", fd);
         return ESP_OK;
@@ -370,6 +489,11 @@ void websocket_init_log_capture(void)
 
     s_orig_vprintf = esp_log_set_vprintf(websocket_log_vprintf);
     ensure_mutex();
+}
+
+void websocket_client_closed(int fd)
+{
+    ws_clients_remove(fd);
 }
 
 /**

--- a/components/vigilant_engine/src/websocket.c
+++ b/components/vigilant_engine/src/websocket.c
@@ -62,17 +62,15 @@ static bool ws_client_is_connected(int fd)
 static uint32_t next_generation(void)
 {
     uint32_t generation = s_next_generation++;
-    if (s_next_generation == 0) {
-        s_next_generation = 1;
-    }
     return generation;
 }
 
-static void ensure_mutex(void)
+static SemaphoreHandle_t ensure_mutex(void)
 {
     if (!s_ws_mutex) {
         s_ws_mutex = xSemaphoreCreateMutex();
     }
+    return s_ws_mutex; // returns NULL on failure, but we check for that in callers
 }
 
 static uint32_t ws_clients_add(int fd)

--- a/components/vigilant_engine/src/websocket.c
+++ b/components/vigilant_engine/src/websocket.c
@@ -132,7 +132,8 @@ static void ws_clients_remove(int fd)
 
 static bool ws_clients_mark_send_queued(int fd, uint32_t *generation)
 {
-    ensure_mutex();
+    SemaphoreHandle_t mutex = ensure_mutex();
+    if (!mutex) return false;
     if (!s_ws_mutex) return false;
 
     bool queued = false;

--- a/main/main.c
+++ b/main/main.c
@@ -33,6 +33,5 @@ void app_main(void)
         uint8_t value = 0;
         ESP_ERROR_CHECK(vigilant_i2c_read_reg8(&device, 0x27, &value)); // Reading a register (e.g. control register)
         ESP_LOGI("app_main i2c test", "reg 0x27 value: 0x%02X", value);
-        ESP_ERROR_CHECK(vigilant_i2c_remove_device(&device)); // Removing a device
     }
 }

--- a/main/main.c
+++ b/main/main.c
@@ -14,24 +14,4 @@ void app_main(void)
         .network_mode = NW_MODE_APSTA
     };
     ESP_ERROR_CHECK(vigilant_init(VgConfig));
-
-    VigilantI2CDevice device = {
-        .address = 0x18,
-        .whoami_reg = 0x0F,
-        .expected_whoami = 0x32,
-        .handle = NULL,
-    };
-
-    ESP_ERROR_CHECK(vigilant_i2c_add_device(&device));
-    esp_err_t i2cerr = vigilant_i2c_whoami_check(&device); // WHOAMI check
-    if (i2cerr != ESP_OK) {
-        status_led_set_state(STATUS_STATE_ERROR);
-        ESP_LOGE("app_main", "I2C WHOAMI check failed: %s", esp_err_to_name(i2cerr));
-    } else {
-        status_led_set_state(STATUS_STATE_INFO);
-        ESP_LOGI("app_main", "I2C WHOAMI check succeeded");
-        uint8_t value = 0;
-        ESP_ERROR_CHECK(vigilant_i2c_read_reg8(&device, 0x27, &value)); // Reading a register (e.g. control register)
-        ESP_LOGI("app_main i2c test", "reg 0x27 value: 0x%02X", value);
-    }
 }

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -37,3 +37,8 @@ CONFIG_HTTPD_SERVER_EVENT_POST_TIMEOUT=2000
 #To enable logging while using the timer
 #Weirdly also fixes the serial time out?
 CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=4096
+
+#
+# LWIP
+#
+CONFIG_LWIP_MAX_SOCKETS=13

--- a/vigilant-engine-frontend/src/shared/styles/theme.css
+++ b/vigilant-engine-frontend/src/shared/styles/theme.css
@@ -5,7 +5,7 @@
 }
 
 body {
-  font-family: ui-monospace, monospace;
+  font-family: Inter, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
   background: radial-gradient(circle at 20% 20%, rgba(96, 165, 250, 0.08), transparent 25%),
     radial-gradient(circle at 80% 0%, rgba(59, 130, 246, 0.06), transparent 22%),
     #0a0e14;

--- a/vigilant-engine-frontend/src/shared/styles/theme.css
+++ b/vigilant-engine-frontend/src/shared/styles/theme.css
@@ -13,9 +13,13 @@ body {
   min-height: 100vh;
   display: flex;
   align-items: stretch;
-  justify-content: center;
   padding: 16px;
   overflow: hidden;
+}
+
+#app {
+  width: 100%;
+  min-height: calc(100vh - 32px);
 }
 
 @keyframes fadeIn {

--- a/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
+++ b/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
@@ -439,22 +439,28 @@ h1 {
 .workspace {
   display: flex;
   flex-direction: column;
-  gap: 16px;
+  gap: 0;
   flex: 1;
   min-height: 0;
 }
 
 .tabs {
   display: flex;
-  gap: 10px;
+  gap: 8px;
   flex-wrap: wrap;
+  align-items: flex-end;
+  padding: 0 14px;
+  margin-bottom: -1px;
+  position: relative;
+  z-index: 2;
 }
 
 .tab {
-  padding: 11px 16px;
-  border-radius: 999px;
+  padding: 12px 18px 13px;
+  border-radius: 12px 12px 0 0;
   border: 1px solid #1f2937;
-  background: rgba(15, 19, 25, 0.82);
+  border-bottom-color: #11161d;
+  background: linear-gradient(180deg, rgba(24, 31, 42, 0.96), rgba(16, 22, 30, 0.92));
   color: #9ca3af;
   font: inherit;
   font-size: 0.78rem;
@@ -463,26 +469,32 @@ h1 {
   text-transform: uppercase;
   cursor: pointer;
   transition: all 0.2s ease;
+  position: relative;
 }
 
 .tab:hover {
   color: #d1d5db;
   border-color: #334155;
-  transform: translateY(-1px);
+  border-bottom-color: #11161d;
+  background: linear-gradient(180deg, rgba(29, 37, 49, 0.98), rgba(18, 24, 33, 0.94));
 }
 
 .tab.active {
   color: #60a5fa;
-  background: rgba(59, 130, 246, 0.12);
+  background: linear-gradient(145deg, #141922, #0f1319);
   border-color: rgba(96, 165, 250, 0.4);
-  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.08);
+  border-bottom-color: #141922;
+  box-shadow:
+    inset 0 1px 0 rgba(96, 165, 250, 0.14),
+    0 -1px 0 rgba(96, 165, 250, 0.08);
+  z-index: 3;
 }
 
 .tab-panel {
   background: linear-gradient(145deg, #141922, #0f1319);
   border: 1px solid #1f2937;
-  border-radius: 10px;
-  padding: 20px;
+  border-radius: 12px;
+  padding: 24px 20px 20px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
   min-height: 0;
   flex: 1;
@@ -687,6 +699,14 @@ h1 {
 
   .actions {
     width: 100%;
+  }
+
+  .tabs {
+    padding: 0 10px;
+  }
+
+  .tab {
+    padding: 11px 14px 12px;
   }
 
   .console-header {

--- a/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
+++ b/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
@@ -265,6 +265,7 @@ const reconnectAttempts = ref(0);
 const pingTimer = ref<number | null>(null);
 const lastHeartbeat = ref<number>(0);
 const connectionOk = ref(false);
+let consoleScrollQueued = false;
 
 const consoleHtml = computed(() =>
   lines.value
@@ -491,10 +492,24 @@ const scrollConsoleToBottom = () => {
   }
 };
 
+function scheduleConsoleScroll() {
+  if (consoleScrollQueued) return;
+  consoleScrollQueued = true;
+  nextTick().then(() => {
+    consoleScrollQueued = false;
+    scrollConsoleToBottom();
+  });
+}
+
+function appendLogLines(newLines: string[]) {
+  if (!newLines.length) return;
+  lines.value = [...lines.value, ...newLines].slice(-MAX_LOG_LINES);
+  scheduleConsoleScroll();
+}
+
 async function pushLine(msg: string) {
-  lines.value = [...lines.value, msg].slice(-MAX_LOG_LINES);
+  appendLogLines([msg]);
   await nextTick();
-  scrollConsoleToBottom();
 }
 
 async function log(msg: string) {
@@ -514,15 +529,13 @@ function handleLogPayload(raw: unknown) {
       payload.lines.filter((line): line is string => typeof line === "string")
     );
     lines.value = normalized.slice(-MAX_LOG_LINES);
-    nextTick().then(scrollConsoleToBottom);
+    scheduleConsoleScroll();
     return;
   }
 
   if (payload.type === "log" && typeof payload.line === "string") {
     const merged = splitAndNormalize(payload.line);
-    for (const l of merged) {
-      pushLine(l);
-    }
+    appendLogLines(merged);
   }
 }
 
@@ -533,7 +546,9 @@ function clearPingTimer() {
   }
 }
 
-function scheduleReconnect() {
+function scheduleReconnect(ws: WebSocket) {
+  if (socket.value !== ws) return;
+
   if (reconnectHandle.value !== null) return;
   socket.value = null;
   connectionOk.value = false;
@@ -564,11 +579,21 @@ function connectLogStream() {
   socket.value = ws;
 
   ws.addEventListener("open", () => {
+    if (socket.value !== ws) {
+      try { ws.close(); } catch (_) {}
+      return;
+    }
+
     reconnectAttempts.value = 0;
     lastHeartbeat.value = performance.now();
     connectionOk.value = true;
 
-    pingTimer.value = window.setInterval(() => {
+    const timer = window.setInterval(() => {
+      if (socket.value !== ws) {
+        clearInterval(timer);
+        return;
+      }
+
       if (ws.readyState !== WebSocket.OPEN) {
         return;
       }
@@ -582,9 +607,11 @@ function connectLogStream() {
 
       try { ws.send('{"type":"ping"}'); } catch (_) {}
     }, PING_INTERVAL_MS);
+    pingTimer.value = timer;
   });
 
   ws.addEventListener("message", (event) => {
+    if (socket.value !== ws) return;
     if (typeof event.data !== "string") return;
     lastHeartbeat.value = performance.now();
     connectionOk.value = true;
@@ -595,10 +622,11 @@ function connectLogStream() {
     }
   });
 
-  ws.addEventListener("close", scheduleReconnect);
+  ws.addEventListener("close", () => scheduleReconnect(ws));
   ws.addEventListener("error", () => {
+    if (socket.value !== ws) return;
     connectionOk.value = false;
-    scheduleReconnect();
+    scheduleReconnect(ws);
     try { ws.close(); } catch (_) {}
   });
 }

--- a/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
+++ b/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
@@ -48,32 +48,38 @@
             <div class="connected-section-title">Detected Devices</div>
           </div>
 
-          <button
-            v-for="device in connectedDevices"
-            :key="device.id"
-            type="button"
-            class="connected-device"
-            :class="{ active: activeConnectedDevice.id === device.id }"
-            :aria-pressed="selectedConnectedDeviceId === device.id"
-            @click="selectedConnectedDeviceId = device.id"
-            @mouseenter="hoveredConnectedDeviceId = device.id"
-            @mouseleave="hoveredConnectedDeviceId = null"
-            @focus="hoveredConnectedDeviceId = device.id"
-            @blur="hoveredConnectedDeviceId = null"
-          >
-            <div class="connected-device-copy">
-              <div class="connected-device-name">{{ device.name }}</div>
-            </div>
-            <span
-              class="protocol-pill"
-              :class="protocolPillClass(device.protocol)"
+          <template v-if="connectedDevices.length">
+            <button
+              v-for="device in connectedDevices"
+              :key="device.id"
+              type="button"
+              class="connected-device"
+              :class="{ active: activeConnectedDevice?.id === device.id }"
+              :aria-pressed="selectedConnectedDeviceId === device.id"
+              @click="selectedConnectedDeviceId = device.id"
+              @mouseenter="hoveredConnectedDeviceId = device.id"
+              @mouseleave="hoveredConnectedDeviceId = null"
+              @focus="hoveredConnectedDeviceId = device.id"
+              @blur="hoveredConnectedDeviceId = null"
             >
-              {{ protocolLabel(device.protocol) }}
-            </span>
-          </button>
+              <div class="connected-device-copy">
+                <div class="connected-device-name">{{ device.name }}</div>
+              </div>
+              <span
+                class="protocol-pill"
+                :class="protocolPillClass(device.protocol)"
+              >
+                {{ protocolLabel(device.protocol) }}
+              </span>
+            </button>
+          </template>
+
+          <div v-else class="connected-empty">
+            No connected devices reported.
+          </div>
         </div>
 
-        <div class="connected-detail">
+        <div v-if="activeConnectedDevice" class="connected-detail">
           <div class="connected-detail-header">
             <div class="connected-detail-name">{{ activeConnectedDevice.name }}</div>
             <span
@@ -94,6 +100,13 @@
               <dd>{{ detail.value }}</dd>
             </div>
           </dl>
+        </div>
+
+        <div v-else class="connected-detail connected-empty-panel">
+          <div class="connected-section-title">Device Details</div>
+          <div class="connected-empty">
+            No I2C devices are currently available from `/i2cinfo`.
+          </div>
         </div>
       </section>
 
@@ -147,8 +160,23 @@ type ConnectedDevice = {
   id: string;
   name: string;
   protocol: ProtocolId;
-  summary: string;
   details: Array<{ label: string; value: string }>;
+};
+type I2cApiDevice = {
+  name?: unknown;
+  address?: unknown;
+  address_hex?: unknown;
+  whoami_reg?: unknown;
+  whoami_reg_hex?: unknown;
+  expected_whoami?: unknown;
+  expected_whoami_hex?: unknown;
+};
+type I2cInfoResponse = {
+  enabled?: unknown;
+  sda_io?: unknown;
+  scl_io?: unknown;
+  frequency_hz?: unknown;
+  devices?: unknown;
 };
 
 const MAX_LOG_LINES = 200;
@@ -159,92 +187,13 @@ const tabs = [
   { id: "connected-devices", label: "Connected Devices" },
   { id: "settings", label: "Settings" },
 ] as const;
-const connectedDevices: ConnectedDevice[] = [
-  {
-    id: "bme688",
-    name: "BME688 Environmental Sensor",
-    protocol: "i2c",
-    summary: "Air quality and temperature sensor on the sensor bus.",
-    details: [
-      { label: "Address", value: "0x76" },
-      { label: "Bus", value: "I2C0 @ 400 kHz" },
-      { label: "Polling", value: "1 Hz" },
-      { label: "Power", value: "3.3 V" },
-      { label: "Status", value: "Streaming" },
-    ],
-  },
-  {
-    id: "ina260",
-    name: "INA260 Power Monitor",
-    protocol: "i2c",
-    summary: "Rail telemetry for the primary 12 V supply.",
-    details: [
-      { label: "Address", value: "0x40" },
-      { label: "Bus", value: "I2C0 @ 400 kHz" },
-      { label: "Alert Pin", value: "GPIO7" },
-      { label: "Range", value: "0-15 A" },
-      { label: "Status", value: "Online" },
-    ],
-  },
-  {
-    id: "ads131m04",
-    name: "ADS131M04 ADC",
-    protocol: "spi",
-    summary: "High-resolution analog front-end for sensor capture.",
-    details: [
-      { label: "Chip Select", value: "GPIO10" },
-      { label: "SPI Mode", value: "Mode 1" },
-      { label: "Clock", value: "8 MHz" },
-      { label: "DRDY", value: "GPIO6" },
-      { label: "Status", value: "Sampling" },
-    ],
-  },
-  {
-    id: "fram",
-    name: "External FRAM Buffer",
-    protocol: "spi",
-    summary: "Non-volatile event buffer for short outage capture.",
-    details: [
-      { label: "Chip Select", value: "GPIO11" },
-      { label: "SPI Mode", value: "Mode 0" },
-      { label: "Clock", value: "4 MHz" },
-      { label: "Capacity", value: "256 kB" },
-      { label: "Status", value: "Mounted" },
-    ],
-  },
-  {
-    id: "inverter-node",
-    name: "Inverter Telemetry Node",
-    protocol: "canfd",
-    summary: "Powertrain node publishing fast diagnostic frames.",
-    details: [
-      { label: "Arbitration ID", value: "0x221" },
-      { label: "Nominal Rate", value: "500 kbps" },
-      { label: "Data Rate", value: "2 Mbps" },
-      { label: "Last Frame", value: "24 ms ago" },
-      { label: "Status", value: "Healthy" },
-    ],
-  },
-  {
-    id: "service-laptop",
-    name: "Service Laptop",
-    protocol: "wifi",
-    summary: "Maintenance station connected to the local AP.",
-    details: [
-      { label: "IP Address", value: "192.168.13.42" },
-      { label: "MAC Address", value: "AC:DE:48:00:11:9A" },
-      { label: "RSSI", value: "-54 dBm" },
-      { label: "SSID", value: "Vigilant-Lab" },
-      { label: "Status", value: "Connected" },
-    ],
-  },
-];
 type TabId = (typeof tabs)[number]["id"];
 
 const deviceName = ref("Vigilant ESP Test");
 const statusText = ref("System Operational");
 const activeTab = ref<TabId>("console");
-const selectedConnectedDeviceId = ref(connectedDevices[0]?.id ?? "");
+const connectedDevices = ref<ConnectedDevice[]>([]);
+const selectedConnectedDeviceId = ref("");
 const hoveredConnectedDeviceId = ref<string | null>(null);
 
 const overlayActive = ref(false);
@@ -266,9 +215,9 @@ const consoleHtml = computed(() =>
 );
 const activeConnectedDevice = computed(
   () =>
-    connectedDevices.find(
+    connectedDevices.value.find(
       (device) => device.id === (hoveredConnectedDeviceId.value ?? selectedConnectedDeviceId.value)
-    ) ?? connectedDevices[0]
+    ) ?? connectedDevices.value[0] ?? null
 );
 
 function escapeHtml(s: string) {
@@ -325,10 +274,77 @@ function protocolPillClass(protocol: ProtocolId) {
   return `protocol-${protocol}`;
 }
 
+function asString(value: unknown) {
+  return typeof value === "string" && value.trim() ? value : null;
+}
+
+function asNumber(value: unknown) {
+  return typeof value === "number" && Number.isFinite(value) ? value : null;
+}
+
+function formatHexByte(value: number | null) {
+  if (value === null) return "n/a";
+  return `0x${value.toString(16).toUpperCase().padStart(2, "0")}`;
+}
+
+function formatI2cBusLabel(response: I2cInfoResponse) {
+  const scl = asNumber(response.scl_io);
+  const sda = asNumber(response.sda_io);
+  const frequencyHz = asNumber(response.frequency_hz);
+  const busParts = ["I2C0"];
+
+  if (frequencyHz !== null) {
+    busParts.push(`@ ${Math.round(frequencyHz / 1000)} kHz`);
+  }
+
+  if (scl !== null && sda !== null) {
+    busParts.push(`SCL ${scl} / SDA ${sda}`);
+  }
+
+  return busParts.join(" ");
+}
+
+function mapI2cDevices(response: I2cInfoResponse): ConnectedDevice[] {
+  if (response.enabled !== true || !Array.isArray(response.devices)) {
+    return [];
+  }
+
+  const busLabel = formatI2cBusLabel(response);
+
+  return response.devices.flatMap((rawDevice) => {
+    if (!rawDevice || typeof rawDevice !== "object") {
+      return [];
+    }
+
+    const device = rawDevice as I2cApiDevice;
+    const address = asNumber(device.address);
+    if (address === null) {
+      return [];
+    }
+
+    const addressHex = asString(device.address_hex) ?? formatHexByte(address);
+    const whoamiReg = asNumber(device.whoami_reg);
+    const expectedWhoami = asNumber(device.expected_whoami);
+
+    return [
+      {
+        id: `i2c-${addressHex.toLowerCase()}`,
+        name: asString(device.name) ?? `I2C Device ${addressHex}`,
+        protocol: "i2c",
+        details: [
+          { label: "Address", value: addressHex },
+          { label: "Bus", value: busLabel },
+          { label: "WHOAMI Reg", value: asString(device.whoami_reg_hex) ?? formatHexByte(whoamiReg) },
+          { label: "Expected WHOAMI", value: asString(device.expected_whoami_hex) ?? formatHexByte(expectedWhoami) },
+        ],
+      },
+    ];
+  });
+}
+
 async function loadDeviceInfo() {
-  const INFO_URL = "http://192.168.13.234/info";
   try {
-    const res = await fetch(INFO_URL, { cache: "no-cache" });
+    const res = await fetch("/info", { cache: "no-cache" });
     if (!res.ok) throw new Error(`HTTP ${res.status}`);
     const data = await res.json();
     if (typeof data?.name === "string" && data.name.trim()) {
@@ -336,6 +352,33 @@ async function loadDeviceInfo() {
     }
   } catch (err) {
     console.warn("Failed to load device info", err);
+  }
+}
+
+async function loadConnectedDevices() {
+  try {
+    const res = await fetch("/i2cinfo", { cache: "no-cache" });
+    if (!res.ok) throw new Error(`HTTP ${res.status}`);
+
+    const data = (await res.json()) as I2cInfoResponse;
+    const devices = mapI2cDevices(data);
+
+    connectedDevices.value = devices;
+    hoveredConnectedDeviceId.value = null;
+
+    if (!devices.length) {
+      selectedConnectedDeviceId.value = "";
+      return;
+    }
+
+    if (!devices.some((device) => device.id === selectedConnectedDeviceId.value)) {
+      selectedConnectedDeviceId.value = devices[0].id;
+    }
+  } catch (err) {
+    connectedDevices.value = [];
+    selectedConnectedDeviceId.value = "";
+    hoveredConnectedDeviceId.value = null;
+    console.warn("Failed to load connected devices", err);
   }
 }
 
@@ -462,11 +505,16 @@ watch(activeTab, async (tabId) => {
     await nextTick();
     scrollConsoleToBottom();
   }
+
+  if (tabId === "connected-devices") {
+    loadConnectedDevices();
+  }
 });
 
 onMounted(() => {
   connectLogStream();
   loadDeviceInfo();
+  loadConnectedDevices();
 });
 
 onBeforeUnmount(() => {
@@ -741,6 +789,16 @@ h1 {
 
 .connected-list {
   align-items: flex-start;
+}
+
+.connected-empty {
+  color: #6b7280;
+  font-size: 0.84rem;
+  line-height: 1.5;
+}
+
+.connected-empty-panel {
+  justify-content: center;
 }
 
 .connected-list-header,

--- a/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
+++ b/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
@@ -45,33 +45,71 @@
       <section v-else-if="activeTab === 'connected-devices'" class="tab-panel connected-panel">
         <div class="connected-list">
           <div class="connected-list-header">
-            <div class="connected-section-title">Detected Devices</div>
+            <div class="connected-section-title">Connected Devices</div>
           </div>
 
           <template v-if="connectedDevices.length">
-            <button
-              v-for="device in connectedDevices"
-              :key="device.id"
-              type="button"
-              class="connected-device"
-              :class="{ active: activeConnectedDevice?.id === device.id }"
-              :aria-pressed="selectedConnectedDeviceId === device.id"
-              @click="selectedConnectedDeviceId = device.id"
-              @mouseenter="hoveredConnectedDeviceId = device.id"
-              @mouseleave="hoveredConnectedDeviceId = null"
-              @focus="hoveredConnectedDeviceId = device.id"
-              @blur="hoveredConnectedDeviceId = null"
-            >
-              <div class="connected-device-copy">
-                <div class="connected-device-name">{{ device.name }}</div>
-              </div>
-              <span
-                class="protocol-pill"
-                :class="protocolPillClass(device.protocol)"
+            <div v-if="addedConnectedDevices.length" class="connected-list-group">
+              <div class="connected-subsection-title">Added Devices</div>
+
+              <button
+                v-for="device in addedConnectedDevices"
+                :key="device.id"
+                type="button"
+                class="connected-device"
+                :class="{ active: activeConnectedDevice?.id === device.id }"
+                :aria-pressed="selectedConnectedDeviceId === device.id"
+                @click="selectedConnectedDeviceId = device.id"
+                @mouseenter="hoveredConnectedDeviceId = device.id"
+                @mouseleave="hoveredConnectedDeviceId = null"
+                @focus="hoveredConnectedDeviceId = device.id"
+                @blur="hoveredConnectedDeviceId = null"
               >
-                {{ protocolLabel(device.protocol) }}
-              </span>
-            </button>
+                <div class="connected-device-copy">
+                  <div class="connected-device-name">{{ device.name }}</div>
+                </div>
+                <div class="connected-device-badges">
+                  <span class="device-state-pill device-state-added">Added</span>
+                  <span
+                    class="protocol-pill"
+                    :class="protocolPillClass(device.protocol)"
+                  >
+                    {{ protocolLabel(device.protocol) }}
+                  </span>
+                </div>
+              </button>
+            </div>
+
+            <div v-if="detectedOnlyConnectedDevices.length" class="connected-list-group">
+              <div class="connected-subsection-title">Detected Devices</div>
+
+              <button
+                v-for="device in detectedOnlyConnectedDevices"
+                :key="device.id"
+                type="button"
+                class="connected-device"
+                :class="{ active: activeConnectedDevice?.id === device.id }"
+                :aria-pressed="selectedConnectedDeviceId === device.id"
+                @click="selectedConnectedDeviceId = device.id"
+                @mouseenter="hoveredConnectedDeviceId = device.id"
+                @mouseleave="hoveredConnectedDeviceId = null"
+                @focus="hoveredConnectedDeviceId = device.id"
+                @blur="hoveredConnectedDeviceId = null"
+              >
+                <div class="connected-device-copy">
+                  <div class="connected-device-name">{{ device.name }}</div>
+                </div>
+                <div class="connected-device-badges">
+                  <span class="device-state-pill device-state-detected">Detected</span>
+                  <span
+                    class="protocol-pill"
+                    :class="protocolPillClass(device.protocol)"
+                  >
+                    {{ protocolLabel(device.protocol) }}
+                  </span>
+                </div>
+              </button>
+            </div>
           </template>
 
           <div v-else class="connected-empty">
@@ -82,12 +120,24 @@
         <div v-if="activeConnectedDevice" class="connected-detail">
           <div class="connected-detail-header">
             <div class="connected-detail-name">{{ activeConnectedDevice.name }}</div>
-            <span
-              class="protocol-pill"
-              :class="protocolPillClass(activeConnectedDevice.protocol)"
-            >
-              {{ protocolLabel(activeConnectedDevice.protocol) }}
-            </span>
+            <div class="connected-device-badges">
+              <span
+                class="device-state-pill"
+                :class="
+                  activeConnectedDevice.state === 'added'
+                    ? 'device-state-added'
+                    : 'device-state-detected'
+                "
+              >
+                {{ activeConnectedDevice.state === "added" ? "Added" : "Detected" }}
+              </span>
+              <span
+                class="protocol-pill"
+                :class="protocolPillClass(activeConnectedDevice.protocol)"
+              >
+                {{ protocolLabel(activeConnectedDevice.protocol) }}
+              </span>
+            </div>
           </div>
 
           <dl class="connected-detail-grid">
@@ -156,13 +206,15 @@
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 type ProtocolId = "i2c" | "spi" | "canfd" | "wifi";
+type DeviceState = "added" | "detected";
 type ConnectedDevice = {
   id: string;
   name: string;
   protocol: ProtocolId;
+  state: DeviceState;
   details: Array<{ label: string; value: string }>;
 };
-type I2cApiDevice = {
+type I2cAddedApiDevice = {
   name?: unknown;
   address?: unknown;
   address_hex?: unknown;
@@ -171,12 +223,18 @@ type I2cApiDevice = {
   expected_whoami?: unknown;
   expected_whoami_hex?: unknown;
 };
+type I2cDetectedApiDevice = {
+  name?: unknown;
+  address?: unknown;
+  address_hex?: unknown;
+};
 type I2cInfoResponse = {
   enabled?: unknown;
   sda_io?: unknown;
   scl_io?: unknown;
   frequency_hz?: unknown;
-  devices?: unknown;
+  added_devices?: unknown;
+  detected_devices?: unknown;
 };
 
 const MAX_LOG_LINES = 200;
@@ -212,6 +270,12 @@ const consoleHtml = computed(() =>
   lines.value
     .map((line) => `<span class="log-line ${levelClass(line)}">${escapeHtml(line)}</span>`)
     .join("\n")
+);
+const addedConnectedDevices = computed(() =>
+  connectedDevices.value.filter((device) => device.state === "added")
+);
+const detectedOnlyConnectedDevices = computed(() =>
+  connectedDevices.value.filter((device) => device.state === "detected")
 );
 const activeConnectedDevice = computed(
   () =>
@@ -305,24 +369,28 @@ function formatI2cBusLabel(response: I2cInfoResponse) {
 }
 
 function mapI2cDevices(response: I2cInfoResponse): ConnectedDevice[] {
-  if (response.enabled !== true || !Array.isArray(response.devices)) {
+  if (response.enabled !== true) {
     return [];
   }
 
   const busLabel = formatI2cBusLabel(response);
+  const addedDevices = Array.isArray(response.added_devices) ? response.added_devices : [];
+  const detectedDevices = Array.isArray(response.detected_devices) ? response.detected_devices : [];
+  const addedAddresses = new Set<string>();
 
-  return response.devices.flatMap((rawDevice) => {
+  const mappedAddedDevices = addedDevices.flatMap((rawDevice) => {
     if (!rawDevice || typeof rawDevice !== "object") {
       return [];
     }
 
-    const device = rawDevice as I2cApiDevice;
+    const device = rawDevice as I2cAddedApiDevice;
     const address = asNumber(device.address);
     if (address === null) {
       return [];
     }
 
     const addressHex = asString(device.address_hex) ?? formatHexByte(address);
+    addedAddresses.add(addressHex);
     const whoamiReg = asNumber(device.whoami_reg);
     const expectedWhoami = asNumber(device.expected_whoami);
 
@@ -331,15 +399,50 @@ function mapI2cDevices(response: I2cInfoResponse): ConnectedDevice[] {
         id: `i2c-${addressHex.toLowerCase()}`,
         name: asString(device.name) ?? `I2C Device ${addressHex}`,
         protocol: "i2c",
+        state: "added",
         details: [
           { label: "Address", value: addressHex },
           { label: "Bus", value: busLabel },
+          { label: "Registration", value: "Added through Vigilant API" },
           { label: "WHOAMI Reg", value: asString(device.whoami_reg_hex) ?? formatHexByte(whoamiReg) },
           { label: "Expected WHOAMI", value: asString(device.expected_whoami_hex) ?? formatHexByte(expectedWhoami) },
         ],
       },
     ];
   });
+
+  const mappedDetectedDevices = detectedDevices.flatMap((rawDevice) => {
+    if (!rawDevice || typeof rawDevice !== "object") {
+      return [];
+    }
+
+    const device = rawDevice as I2cDetectedApiDevice;
+    const address = asNumber(device.address);
+    if (address === null) {
+      return [];
+    }
+
+    const addressHex = asString(device.address_hex) ?? formatHexByte(address);
+    if (addedAddresses.has(addressHex)) {
+      return [];
+    }
+
+    return [
+      {
+        id: `i2c-detected-${addressHex.toLowerCase()}`,
+        name: asString(device.name) ?? `Detected I2C Device ${addressHex}`,
+        protocol: "i2c",
+        state: "detected",
+        details: [
+          { label: "Address", value: addressHex },
+          { label: "Bus", value: busLabel },
+          { label: "Registration", value: "Detected on bus, not added" },
+        ],
+      },
+    ];
+  });
+
+  return [...mappedAddedDevices, ...mappedDetectedDevices];
 }
 
 async function loadDeviceInfo() {
@@ -791,6 +894,21 @@ h1 {
   align-items: flex-start;
 }
 
+.connected-list-group {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  width: 100%;
+}
+
+.connected-subsection-title {
+  color: #6b7280;
+  font-size: 0.72rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
 .connected-empty {
   color: #6b7280;
   font-size: 0.84rem;
@@ -861,6 +979,15 @@ h1 {
   min-width: 0;
 }
 
+.connected-device-badges {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 6px;
+  flex-wrap: wrap;
+  flex-shrink: 0;
+}
+
 .connected-device-name {
   color: #e5e7eb;
   font-size: 0.88rem;
@@ -880,6 +1007,30 @@ h1 {
   text-transform: uppercase;
   border: 1px solid #1f2937;
   white-space: nowrap;
+}
+
+.device-state-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px 9px;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid #1f2937;
+  white-space: nowrap;
+}
+
+.device-state-added {
+  color: #34d399;
+  background: rgba(16, 185, 129, 0.12);
+}
+
+.device-state-detected {
+  color: #facc15;
+  background: rgba(234, 179, 8, 0.12);
 }
 
 .protocol-i2c {

--- a/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
+++ b/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
@@ -42,6 +42,61 @@
         <pre ref="consoleEl" class="console" v-html="consoleHtml"></pre>
       </section>
 
+      <section v-else-if="activeTab === 'connected-devices'" class="tab-panel connected-panel">
+        <div class="connected-list">
+          <div class="connected-list-header">
+            <div class="connected-section-title">Detected Devices</div>
+          </div>
+
+          <button
+            v-for="device in connectedDevices"
+            :key="device.id"
+            type="button"
+            class="connected-device"
+            :class="{ active: activeConnectedDevice.id === device.id }"
+            :aria-pressed="selectedConnectedDeviceId === device.id"
+            @click="selectedConnectedDeviceId = device.id"
+            @mouseenter="hoveredConnectedDeviceId = device.id"
+            @mouseleave="hoveredConnectedDeviceId = null"
+            @focus="hoveredConnectedDeviceId = device.id"
+            @blur="hoveredConnectedDeviceId = null"
+          >
+            <div class="connected-device-copy">
+              <div class="connected-device-name">{{ device.name }}</div>
+            </div>
+            <span
+              class="protocol-pill"
+              :class="protocolPillClass(device.protocol)"
+            >
+              {{ protocolLabel(device.protocol) }}
+            </span>
+          </button>
+        </div>
+
+        <div class="connected-detail">
+          <div class="connected-detail-header">
+            <div class="connected-detail-name">{{ activeConnectedDevice.name }}</div>
+            <span
+              class="protocol-pill"
+              :class="protocolPillClass(activeConnectedDevice.protocol)"
+            >
+              {{ protocolLabel(activeConnectedDevice.protocol) }}
+            </span>
+          </div>
+
+          <dl class="connected-detail-grid">
+            <div
+              v-for="detail in activeConnectedDevice.details"
+              :key="detail.label"
+              class="connected-detail-row"
+            >
+              <dt>{{ detail.label }}</dt>
+              <dd>{{ detail.value }}</dd>
+            </div>
+          </dl>
+        </div>
+      </section>
+
       <section v-else-if="activeTab === 'settings'" class="tab-panel settings-panel">
         <div class="settings-group">
           <div class="settings-group-title">Device Settings</div>
@@ -87,6 +142,15 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
+type ProtocolId = "i2c" | "spi" | "canfd" | "wifi";
+type ConnectedDevice = {
+  id: string;
+  name: string;
+  protocol: ProtocolId;
+  summary: string;
+  details: Array<{ label: string; value: string }>;
+};
+
 const MAX_LOG_LINES = 200;
 const PING_INTERVAL_MS = 15000;
 const HEARTBEAT_TIMEOUT_MS = 45000;
@@ -95,11 +159,93 @@ const tabs = [
   { id: "connected-devices", label: "Connected Devices" },
   { id: "settings", label: "Settings" },
 ] as const;
+const connectedDevices: ConnectedDevice[] = [
+  {
+    id: "bme688",
+    name: "BME688 Environmental Sensor",
+    protocol: "i2c",
+    summary: "Air quality and temperature sensor on the sensor bus.",
+    details: [
+      { label: "Address", value: "0x76" },
+      { label: "Bus", value: "I2C0 @ 400 kHz" },
+      { label: "Polling", value: "1 Hz" },
+      { label: "Power", value: "3.3 V" },
+      { label: "Status", value: "Streaming" },
+    ],
+  },
+  {
+    id: "ina260",
+    name: "INA260 Power Monitor",
+    protocol: "i2c",
+    summary: "Rail telemetry for the primary 12 V supply.",
+    details: [
+      { label: "Address", value: "0x40" },
+      { label: "Bus", value: "I2C0 @ 400 kHz" },
+      { label: "Alert Pin", value: "GPIO7" },
+      { label: "Range", value: "0-15 A" },
+      { label: "Status", value: "Online" },
+    ],
+  },
+  {
+    id: "ads131m04",
+    name: "ADS131M04 ADC",
+    protocol: "spi",
+    summary: "High-resolution analog front-end for sensor capture.",
+    details: [
+      { label: "Chip Select", value: "GPIO10" },
+      { label: "SPI Mode", value: "Mode 1" },
+      { label: "Clock", value: "8 MHz" },
+      { label: "DRDY", value: "GPIO6" },
+      { label: "Status", value: "Sampling" },
+    ],
+  },
+  {
+    id: "fram",
+    name: "External FRAM Buffer",
+    protocol: "spi",
+    summary: "Non-volatile event buffer for short outage capture.",
+    details: [
+      { label: "Chip Select", value: "GPIO11" },
+      { label: "SPI Mode", value: "Mode 0" },
+      { label: "Clock", value: "4 MHz" },
+      { label: "Capacity", value: "256 kB" },
+      { label: "Status", value: "Mounted" },
+    ],
+  },
+  {
+    id: "inverter-node",
+    name: "Inverter Telemetry Node",
+    protocol: "canfd",
+    summary: "Powertrain node publishing fast diagnostic frames.",
+    details: [
+      { label: "Arbitration ID", value: "0x221" },
+      { label: "Nominal Rate", value: "500 kbps" },
+      { label: "Data Rate", value: "2 Mbps" },
+      { label: "Last Frame", value: "24 ms ago" },
+      { label: "Status", value: "Healthy" },
+    ],
+  },
+  {
+    id: "service-laptop",
+    name: "Service Laptop",
+    protocol: "wifi",
+    summary: "Maintenance station connected to the local AP.",
+    details: [
+      { label: "IP Address", value: "192.168.13.42" },
+      { label: "MAC Address", value: "AC:DE:48:00:11:9A" },
+      { label: "RSSI", value: "-54 dBm" },
+      { label: "SSID", value: "Vigilant-Lab" },
+      { label: "Status", value: "Connected" },
+    ],
+  },
+];
 type TabId = (typeof tabs)[number]["id"];
 
 const deviceName = ref("Vigilant ESP Test");
 const statusText = ref("System Operational");
 const activeTab = ref<TabId>("console");
+const selectedConnectedDeviceId = ref(connectedDevices[0]?.id ?? "");
+const hoveredConnectedDeviceId = ref<string | null>(null);
 
 const overlayActive = ref(false);
 const proceeding = ref(false);
@@ -117,6 +263,12 @@ const consoleHtml = computed(() =>
   lines.value
     .map((line) => `<span class="log-line ${levelClass(line)}">${escapeHtml(line)}</span>`)
     .join("\n")
+);
+const activeConnectedDevice = computed(
+  () =>
+    connectedDevices.find(
+      (device) => device.id === (hoveredConnectedDeviceId.value ?? selectedConnectedDeviceId.value)
+    ) ?? connectedDevices[0]
 );
 
 function escapeHtml(s: string) {
@@ -161,6 +313,16 @@ function normalizeLogLines(rawLines: string[]): string[] {
 
 function splitAndNormalize(text: string) {
   return normalizeLogLines(text.split(/\r?\n/));
+}
+
+function protocolLabel(protocol: ProtocolId) {
+  if (protocol === "canfd") return "CAN FD";
+  if (protocol === "wifi") return "WiFi";
+  return protocol.toUpperCase();
+}
+
+function protocolPillClass(protocol: ProtocolId) {
+  return `protocol-${protocol}`;
 }
 
 async function loadDeviceInfo() {
@@ -354,6 +516,25 @@ async function proceed() {
 </script>
 
 <style scoped>
+.container,
+.tab,
+.btn-danger,
+.btn-primary,
+.connected-device,
+.protocol-pill,
+.pill,
+.settings-group-title,
+.connected-section-title,
+.connected-device-name,
+.connected-detail-name,
+.status,
+.console-sub,
+.modal,
+.credentials,
+.label {
+  font-family: Inter, "Segoe UI", "Helvetica Neue", Arial, sans-serif;
+}
+
 .container {
   width: 100%;
   padding: 24px;
@@ -364,6 +545,7 @@ async function proceed() {
 }
 
 h1 {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: 2.1rem;
   font-weight: 700;
   letter-spacing: -0.02em;
@@ -375,6 +557,7 @@ h1 {
 }
 
 .device-name {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   font-size: 0.8125rem;
   color: #60a5fa;
   font-weight: 600;
@@ -394,6 +577,7 @@ h1 {
 }
 
 .ws-chip {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   display: inline-flex;
   align-items: center;
   gap: 6px;
@@ -500,6 +684,7 @@ h1 {
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
   min-height: 0;
   flex: 1;
+  overflow: hidden;
 }
 
 .btn-danger {
@@ -525,6 +710,168 @@ h1 {
 }
 
 .console-panel { display: flex; flex-direction: column; gap: 10px; }
+
+.connected-panel {
+  display: grid;
+  grid-template-columns: minmax(240px, 320px) minmax(0, 1fr);
+  grid-template-rows: minmax(0, 1fr);
+  gap: 14px;
+  align-content: stretch;
+  padding: 16px;
+}
+
+.connected-list,
+.connected-detail {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  min-height: 0;
+  padding: 14px;
+  border-radius: 10px;
+  border: 1px solid #1f2937;
+  background: rgba(13, 17, 23, 0.78);
+  box-shadow: inset 0 1px 0 rgba(255, 255, 255, 0.02);
+  overflow-y: auto;
+  scrollbar-width: thin;
+}
+
+.connected-detail {
+  min-height: 0;
+}
+
+.connected-list {
+  align-items: flex-start;
+}
+
+.connected-list-header,
+.connected-detail-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.connected-section-title {
+  font-size: 0.78rem;
+  color: #9ca3af;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.connected-detail-name {
+  color: #e5e7eb;
+  font-size: 0.96rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+  line-height: 1.25;
+  text-transform: uppercase;
+}
+
+.connected-device {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 10px;
+  width: min(100%, 320px);
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #1f2937;
+  background: linear-gradient(180deg, rgba(15, 19, 25, 0.92), rgba(12, 16, 22, 0.9));
+  color: inherit;
+  font: inherit;
+  cursor: pointer;
+  text-align: left;
+  transition: all 0.2s ease;
+}
+
+.connected-device:hover,
+.connected-device:focus-visible {
+  border-color: #334155;
+  background: linear-gradient(180deg, rgba(20, 26, 35, 0.96), rgba(14, 19, 26, 0.94));
+  outline: none;
+}
+
+.connected-device.active {
+  border-color: rgba(96, 165, 250, 0.35);
+  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.08);
+}
+
+.connected-device-copy {
+  display: flex;
+  flex-direction: column;
+  min-width: 0;
+}
+
+.connected-device-name {
+  color: #e5e7eb;
+  font-size: 0.88rem;
+  font-weight: 600;
+  line-height: 1.3;
+}
+
+.protocol-pill {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  padding: 5px 9px;
+  border-radius: 999px;
+  font-size: 0.68rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  border: 1px solid #1f2937;
+  white-space: nowrap;
+}
+
+.protocol-i2c {
+  color: #60a5fa;
+  background: rgba(59, 130, 246, 0.12);
+}
+
+.protocol-spi {
+  color: #34d399;
+  background: rgba(16, 185, 129, 0.12);
+}
+
+.protocol-canfd {
+  color: #facc15;
+  background: rgba(234, 179, 8, 0.12);
+}
+
+.protocol-wifi {
+  color: #f472b6;
+  background: rgba(236, 72, 153, 0.12);
+}
+
+.connected-detail-grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 10px;
+}
+
+.connected-detail-row {
+  padding: 10px 12px;
+  border-radius: 8px;
+  border: 1px solid #1f2937;
+  background: rgba(10, 14, 20, 0.62);
+}
+
+.connected-detail-row dt {
+  font-size: 0.68rem;
+  color: #6b7280;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  margin-bottom: 4px;
+}
+
+.connected-detail-row dd {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  color: #e5e7eb;
+  font-size: 0.84rem;
+  font-weight: 600;
+  margin: 0;
+}
 
 .settings-panel {
   display: flex;
@@ -598,6 +945,7 @@ h1 {
 .pill-error { background: rgba(248, 113, 113, 0.12); color: #f87171; }
 
 .console {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
   background: #0d1117;
   border: 1px solid #1f2937;
   border-radius: 8px;
@@ -677,6 +1025,9 @@ h1 {
 
 .label { color: #6b7280; }
 .value { color: #60a5fa; font-weight: 600; }
+.value {
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+}
 
 .btn-primary {
   width: 100%;
@@ -733,6 +1084,23 @@ h1 {
 
   .tab {
     padding: 11px 14px 12px;
+  }
+
+  .connected-panel {
+    grid-template-columns: 1fr;
+    grid-template-rows: auto;
+    gap: 12px;
+    padding: 14px;
+    overflow-y: auto;
+  }
+
+  .connected-detail-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .connected-list,
+  .connected-detail {
+    overflow: visible;
   }
 
   .console-header {

--- a/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
+++ b/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
@@ -18,8 +18,21 @@
       </div>
     </header>
 
-    <main class="layout">
-      <section class="console-panel">
+    <main class="workspace">
+      <nav class="tabs" aria-label="Primary sections">
+        <button
+          v-for="tab in tabs"
+          :key="tab.id"
+          type="button"
+          class="tab"
+          :class="{ active: activeTab === tab.id }"
+          @click="activeTab = tab.id"
+        >
+          {{ tab.label }}
+        </button>
+      </nav>
+
+      <section v-if="activeTab === 'console'" class="tab-panel console-panel">
         <div class="console-header">
           <div>
             <div class="console-title">System Console</div>
@@ -34,12 +47,7 @@
         <pre ref="consoleEl" class="console" v-html="consoleHtml"></pre>
       </section>
 
-      <aside class="sidebar">
-        <h3>System Controls</h3>
-        <button class="btn-danger" @click="showRecovery">
-          ⚠️ Reboot to Recovery
-        </button>
-      </aside>
+      <section v-else class="tab-panel tab-panel-empty"></section>
     </main>
 
     <div class="overlay" :class="{ active: overlayActive }">
@@ -73,14 +81,21 @@
 </template>
 
 <script setup lang="ts">
-import { computed, nextTick, onBeforeUnmount, onMounted, ref } from "vue";
+import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
 
 const MAX_LOG_LINES = 200;
 const PING_INTERVAL_MS = 15000;
 const HEARTBEAT_TIMEOUT_MS = 45000;
+const tabs = [
+  { id: "console", label: "Console" },
+  { id: "connected-devices", label: "Connected Devices" },
+  { id: "settings", label: "Settings" },
+] as const;
+type TabId = (typeof tabs)[number]["id"];
 
 const deviceName = ref("Vigilant ESP Test");
 const statusText = ref("System Operational");
+const activeTab = ref<TabId>("console");
 
 const overlayActive = ref(false);
 const proceeding = ref(false);
@@ -276,6 +291,13 @@ function connectLogStream() {
   });
 }
 
+watch(activeTab, async (tabId) => {
+  if (tabId === "console") {
+    await nextTick();
+    scrollConsoleToBottom();
+  }
+});
+
 onMounted(() => {
   connectLogStream();
   loadDeviceInfo();
@@ -329,7 +351,6 @@ async function proceed() {
 
 <style scoped>
 .container {
-  max-width: 1280px;
   width: 100%;
   padding: 24px;
   display: flex;
@@ -415,31 +436,56 @@ h1 {
 
 .actions { display: flex; gap: 12px; }
 
-.layout {
-  display: grid;
-  grid-template-columns: 1fr minmax(240px, 320px);
-  gap: 20px;
-  align-items: stretch;
+.workspace {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
   flex: 1;
   min-height: 0;
 }
 
-.console-panel,
-.sidebar {
+.tabs {
+  display: flex;
+  gap: 10px;
+  flex-wrap: wrap;
+}
+
+.tab {
+  padding: 11px 16px;
+  border-radius: 999px;
+  border: 1px solid #1f2937;
+  background: rgba(15, 19, 25, 0.82);
+  color: #9ca3af;
+  font: inherit;
+  font-size: 0.78rem;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+  cursor: pointer;
+  transition: all 0.2s ease;
+}
+
+.tab:hover {
+  color: #d1d5db;
+  border-color: #334155;
+  transform: translateY(-1px);
+}
+
+.tab.active {
+  color: #60a5fa;
+  background: rgba(59, 130, 246, 0.12);
+  border-color: rgba(96, 165, 250, 0.4);
+  box-shadow: inset 0 0 0 1px rgba(96, 165, 250, 0.08);
+}
+
+.tab-panel {
   background: linear-gradient(145deg, #141922, #0f1319);
   border: 1px solid #1f2937;
   border-radius: 10px;
   padding: 20px;
   box-shadow: 0 4px 20px rgba(0, 0, 0, 0.4);
-}
-
-.sidebar h3 {
-  font-size: 0.85rem;
-  color: #9ca3af;
-  margin-bottom: 16px;
-  text-transform: uppercase;
-  letter-spacing: 0.1em;
-  font-weight: 600;
+  min-height: 0;
+  flex: 1;
 }
 
 .btn-danger {
@@ -465,6 +511,18 @@ h1 {
 }
 
 .console-panel { display: flex; flex-direction: column; gap: 10px; }
+
+.tab-panel-empty {
+  background:
+    linear-gradient(145deg, rgba(20, 25, 34, 0.98), rgba(15, 19, 25, 0.96)),
+    repeating-linear-gradient(
+      135deg,
+      rgba(59, 130, 246, 0.03),
+      rgba(59, 130, 246, 0.03) 18px,
+      transparent 18px,
+      transparent 36px
+    );
+}
 
 .console-header {
   display: flex;
@@ -504,8 +562,8 @@ h1 {
   padding: 14px;
   font-size: 0.84rem;
   line-height: 1.05;
-  min-height: 220px;
-  max-height: 60vh;
+  min-height: 0;
+  height: 100%;
   color: #e5e7eb;
   overflow-y: auto;
   overflow-x: auto;
@@ -616,5 +674,24 @@ h1 {
   border-radius: 50%;
   animation: spin 0.8s linear infinite;
   margin-right: 8px;
+}
+
+@media (max-width: 840px) {
+  .container {
+    padding: 20px 16px;
+  }
+
+  .topbar {
+    flex-direction: column;
+  }
+
+  .actions {
+    width: 100%;
+  }
+
+  .console-header {
+    flex-direction: column;
+    align-items: flex-start;
+  }
 }
 </style>

--- a/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
+++ b/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
@@ -11,11 +11,6 @@
         </div>
         <div class="status">{{ statusText }}</div>
       </div>
-      <div class="actions">
-        <button class="btn-danger" @click="showRecovery">
-          ⚠️ Reboot to Recovery
-        </button>
-      </div>
     </header>
 
     <main class="workspace">
@@ -45,6 +40,15 @@
           </div>
         </div>
         <pre ref="consoleEl" class="console" v-html="consoleHtml"></pre>
+      </section>
+
+      <section v-else-if="activeTab === 'settings'" class="tab-panel settings-panel">
+        <div class="settings-group">
+          <div class="settings-group-title">Device Settings</div>
+          <button class="btn-danger settings-action" @click="showRecovery">
+            ⚠️ Reboot to Recovery
+          </button>
+        </div>
       </section>
 
       <section v-else class="tab-panel tab-panel-empty"></section>
@@ -434,8 +438,6 @@ h1 {
 
 .title-block { display: flex; flex-direction: column; gap: 4px; }
 
-.actions { display: flex; gap: 12px; }
-
 .workspace {
   display: flex;
   flex-direction: column;
@@ -523,6 +525,34 @@ h1 {
 }
 
 .console-panel { display: flex; flex-direction: column; gap: 10px; }
+
+.settings-panel {
+  display: flex;
+  align-items: flex-start;
+}
+
+.settings-group {
+  width: min(100%, 420px);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+  padding: 18px;
+  border-radius: 10px;
+  border: 1px solid #1f2937;
+  background: rgba(13, 17, 23, 0.78);
+}
+
+.settings-group-title {
+  font-size: 0.82rem;
+  color: #9ca3af;
+  font-weight: 700;
+  letter-spacing: 0.08em;
+  text-transform: uppercase;
+}
+
+.settings-action {
+  max-width: 320px;
+}
 
 .tab-panel-empty {
   background:
@@ -695,10 +725,6 @@ h1 {
 
   .topbar {
     flex-direction: column;
-  }
-
-  .actions {
-    width: 100%;
   }
 
   .tabs {

--- a/vigilant-engine-recovery/CMakeLists.txt
+++ b/vigilant-engine-recovery/CMakeLists.txt
@@ -1,28 +1,21 @@
-# The following lines of boilerplate have to be in your project's
-# CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 # "Trim" the build. Include the minimal set of components, main, and anything it depends on.
 idf_build_set_property(MINIMAL_BUILD ON)
-project(vigilant-engine-recovery)
 
 # ---- Web UI (Vite) build integration ----
 option(VE_BUILD_WEB "Build Vite UI before compiling firmware" ON)
 
+get_filename_component(VE_REPO_ROOT "${CMAKE_SOURCE_DIR}/.." ABSOLUTE)
+set(VE_NODE_ROOT_DIR "${VE_REPO_ROOT}")
+set(VE_WEB_DIR "${VE_REPO_ROOT}/vigilant-engine-frontend")
+set(VE_RECOVERY_HTML "${VE_REPO_ROOT}/build/static/recovery/index.html")
+
+idf_build_set_property(VE_BUILD_WEB "${VE_BUILD_WEB}")
+idf_build_set_property(VE_RECOVERY_HTML "${VE_RECOVERY_HTML}")
+
 if(VE_BUILD_WEB)
-  find_program(NPM_EXECUTABLE npm)
-  if(NOT NPM_EXECUTABLE)
-    message(FATAL_ERROR "npm not found. Install Node.js/npm or set VE_BUILD_WEB=OFF.")
-  endif()
-
-  get_filename_component(VE_REPO_ROOT "${CMAKE_SOURCE_DIR}/.." ABSOLUTE)
-  set(VE_NODE_ROOT_DIR "${VE_REPO_ROOT}")
-  set(VE_WEB_DIR "${VE_REPO_ROOT}/vigilant-engine-frontend")
-
-  set(VE_OUT_RECOVERY "${CMAKE_SOURCE_DIR}/main/static/index.html")
-  set(VE_WEB_STAMP "${CMAKE_BINARY_DIR}/ve_web_build.stamp")
-
   file(GLOB_RECURSE VE_WEB_SOURCES CONFIGURE_DEPENDS
     "${VE_NODE_ROOT_DIR}/package.json"
     "${VE_NODE_ROOT_DIR}/package-lock.json"
@@ -38,20 +31,26 @@ if(VE_BUILD_WEB)
     "${VE_WEB_DIR}/src/*"
   )
 
+  find_program(NPM_EXECUTABLE npm)
+  if(NOT NPM_EXECUTABLE)
+    message(FATAL_ERROR "npm not found. Install Node.js/npm or set VE_BUILD_WEB=OFF.")
+  endif()
+
   add_custom_command(
-    OUTPUT "${VE_WEB_STAMP}"
+    OUTPUT "${VE_RECOVERY_HTML}"
 
     COMMAND "${CMAKE_COMMAND}" -E chdir "${VE_NODE_ROOT_DIR}" "${NPM_EXECUTABLE}" install
     COMMAND "${CMAKE_COMMAND}" -E chdir "${VE_WEB_DIR}" "${NPM_EXECUTABLE}" install
     COMMAND "${CMAKE_COMMAND}" -E chdir "${VE_WEB_DIR}" "${NPM_EXECUTABLE}" run build:recovery
 
-    COMMAND "${CMAKE_COMMAND}" -E touch "${VE_WEB_STAMP}"
-
     DEPENDS ${VE_WEB_SOURCES}
-    BYPRODUCTS "${VE_OUT_RECOVERY}"
     COMMENT "Building Vite UI (recovery)"
     VERBATIM
   )
 
-  add_custom_target(ve_web ALL DEPENDS "${VE_WEB_STAMP}")
+  add_custom_target(ve_web ALL DEPENDS "${VE_RECOVERY_HTML}")
 endif()
+
+# Keep project() after ve_web so the main component can depend on the generated
+# build/static/recovery/index.html before ESP-IDF creates the embed rule.
+project(vigilant-engine-recovery)

--- a/vigilant-engine-recovery/main/CMakeLists.txt
+++ b/vigilant-engine-recovery/main/CMakeLists.txt
@@ -1,8 +1,23 @@
+idf_build_get_property(recovery_html VE_RECOVERY_HTML)
+idf_build_get_property(ve_build_web VE_BUILD_WEB)
+
+if(NOT recovery_html)
+    idf_build_get_property(build_dir BUILD_DIR)
+    set(recovery_html "${build_dir}/static/recovery/index.html")
+endif()
+
+if(NOT ve_build_web AND NOT EXISTS "${recovery_html}")
+    message(FATAL_ERROR
+        "Recovery UI HTML is missing and VE_BUILD_WEB=OFF.\n"
+        "Expected prebuilt file at ${recovery_html}."
+    )
+endif()
+
 idf_component_register(
     SRCS "recovery_app.c"
     INCLUDE_DIRS "."
     EMBED_FILES 
-        "static/index.html"
+        "${recovery_html}"
     REQUIRES esp_wifi esp_netif esp_event nvs_flash esp_http_server app_update esp_partition
 )
 


### PR DESCRIPTION
This pull request adds a new `/i2cinfo` HTTP endpoint to expose detailed I2C bus and device information, and refactors the I2C device management to track and report both registered and detected I2C devices. It also introduces new data structures and APIs to support this functionality, and updates the frontend theme for improved UI consistency.

The new "Connected Devices" tab should be used for all kinds of peripherals in the future, not just I2C devices.

<img width="1919" height="1025" alt="image" src="https://github.com/user-attachments/assets/50ef6608-2f6e-4e27-82f8-2f929c8eea33" />

**I2C Bus and Device Information Exposure:**

* Added a new `VigilantI2cInfo` struct and `vigilant_get_i2cinfo` API to collect and report I2C bus configuration, registered devices, and detected devices (`vigilant.h`, `vigilant.c`). [[1]](diffhunk://#diff-687ef94dcc7638d3a18ae2c05c160d2c4d4e3891f621110854c45a4f2ed88b84R31-R44) [[2]](diffhunk://#diff-d52558f72de77e889614e06c30de798f09e6a23afe50036ed902f11dd648c1d0R326-R365)
* Implemented `/i2cinfo` HTTP GET endpoint that returns a JSON payload with I2C bus status, registered devices, and detected device addresses (`http_server.c`). [[1]](diffhunk://#diff-1848c2305024f39f33d860610357e22507dea5870958da4775bdcd9fb53888f6R234-R346) [[2]](diffhunk://#diff-1848c2305024f39f33d860610357e22507dea5870958da4775bdcd9fb53888f6R410)

**I2C Device Detection and Tracking:**

* Added device scanning, detection, and result caching in the I2C driver, with APIs to retrieve detected devices and keep the list up to date (`i2c.c`, `i2c.h`). [[1]](diffhunk://#diff-b8cf23bacff49d34c4c292cd73fc0e0b8c6c0ece023b108e235b20ac148885a7L19-R37) [[2]](diffhunk://#diff-b8cf23bacff49d34c4c292cd73fc0e0b8c6c0ece023b108e235b20ac148885a7R46-R139) [[3]](diffhunk://#diff-b8cf23bacff49d34c4c292cd73fc0e0b8c6c0ece023b108e235b20ac148885a7R248-R269) [[4]](diffhunk://#diff-b8cf23bacff49d34c4c292cd73fc0e0b8c6c0ece023b108e235b20ac148885a7R280-R281) [[5]](diffhunk://#diff-c2fd6272821dfa4540dc0715a77ba7cb100a68046b9b5b9a613c2e6df95e7a0dR3-R4) [[6]](diffhunk://#diff-c2fd6272821dfa4540dc0715a77ba7cb100a68046b9b5b9a613c2e6df95e7a0dR18)
* Refactored device registration logic to maintain a fixed-size registry of added devices and synchronize it with I2C operations (`vigilant.c`). [[1]](diffhunk://#diff-d52558f72de77e889614e06c30de798f09e6a23afe50036ed902f11dd648c1d0R27-R34) [[2]](diffhunk://#diff-d52558f72de77e889614e06c30de798f09e6a23afe50036ed902f11dd648c1d0R56-R108) [[3]](diffhunk://#diff-d52558f72de77e889614e06c30de798f09e6a23afe50036ed902f11dd648c1d0R326-R365) [[4]](diffhunk://#diff-d52558f72de77e889614e06c30de798f09e6a23afe50036ed902f11dd648c1d0L283-R379)

**Frontend/UI Improvements:**

* Changed the default font family and improved layout sizing in the frontend theme for a more modern and consistent appearance (`theme.css`).

**Other:**

* Removed an unnecessary call to remove the I2C device in the main application example (`main.c`).

This PR closes #8 #12 #48 