### PR TITLE
Flash improvements and webserver speedup

### DIFF
--- a/.github/workflows/esp-build.yml
+++ b/.github/workflows/esp-build.yml
@@ -3,10 +3,8 @@ name: Frontend and Firmware CI
 on:
   push:
     branches:
-      - main
+      - "**"
   pull_request:
-    branches:
-      - main
 
 permissions:
   contents: read
@@ -52,6 +50,9 @@ jobs:
   firmware:
     runs-on: ubuntu-latest
     needs: frontend
+    if: >-
+      (github.event_name == 'push' && github.ref == 'refs/heads/main') ||
+      (github.event_name == 'pull_request' && github.base_ref == 'main')
 
     steps:
       - name: Checkout repository

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -16,3 +16,91 @@ idf_build_set_property(MINIMAL_BUILD ON)
 idf_build_set_property(VE_BUILD_WEB "${VE_BUILD_WEB}")
 idf_build_set_property(VE_VIGILANT_HTML "${VE_VIGILANT_HTML}")
 project(vigilant-engine)
+
+idf_build_get_property(VE_BUILD_DIR BUILD_DIR)
+idf_build_get_property(VE_PROJECT_BIN PROJECT_BIN)
+idf_build_get_property(VE_PYTHON PYTHON)
+idf_build_get_property(VE_IDF_TARGET IDF_TARGET)
+idf_build_get_property(VE_IDF_PATH IDF_PATH)
+
+partition_table_get_partition_info(VE_MAIN_APP_OFFSET "--partition-name ota_0" "offset")
+partition_table_get_partition_info(VE_RECOVERY_APP_OFFSET "--partition-name factory" "offset")
+
+if(NOT VE_MAIN_APP_OFFSET)
+    message(FATAL_ERROR "Could not find ota_0 partition offset for main firmware flashing.")
+endif()
+
+if(NOT VE_RECOVERY_APP_OFFSET)
+    message(FATAL_ERROR "Could not find factory partition offset for recovery firmware flashing.")
+endif()
+
+set(VE_RECOVERY_PROJECT_DIR "${CMAKE_SOURCE_DIR}/vigilant-engine-recovery")
+set(VE_RECOVERY_BIN "${VE_RECOVERY_PROJECT_DIR}/build/vigilant-engine-recovery.bin")
+set(VE_RECOVERY_PARTITIONS_CSV "${VE_RECOVERY_PROJECT_DIR}/partitions.csv")
+get_filename_component(VE_PYTHON_BIN_DIR "${VE_PYTHON}" DIRECTORY)
+get_filename_component(VE_PYTHON_ENV_PATH "${VE_PYTHON_BIN_DIR}" DIRECTORY)
+get_filename_component(VE_TOOLCHAIN_BIN_DIR "${CMAKE_C_COMPILER}" DIRECTORY)
+
+set(VE_ESP_IDF_VERSION "$ENV{ESP_IDF_VERSION}")
+if(NOT VE_ESP_IDF_VERSION)
+    set(VE_ESP_IDF_VERSION "${IDF_VERSION_MAJOR}.${IDF_VERSION_MINOR}")
+endif()
+set(VE_IDF_TOOLS_PATH "$ENV{IDF_TOOLS_PATH}")
+if(NOT VE_IDF_TOOLS_PATH)
+    set(VE_IDF_TOOLS_PATH "$ENV{HOME}/.espressif")
+endif()
+set(VE_ESP_ROM_ELF_DIR "$ENV{ESP_ROM_ELF_DIR}")
+
+function(ve_remove_default_project_bin target_name)
+    if(NOT TARGET ${target_name})
+        return()
+    endif()
+
+    foreach(property_name IN ITEMS IMAGES ENCRYPTED_IMAGES NON_ENCRYPTED_IMAGES FLASH_FILE FLASH_ENTRY)
+        get_property(property_values TARGET ${target_name} PROPERTY ${property_name})
+        set(filtered_values)
+
+        foreach(property_value IN LISTS property_values)
+            string(FIND "${property_value}" "${VE_PROJECT_BIN}" project_bin_index)
+            if(project_bin_index EQUAL -1)
+                list(APPEND filtered_values "${property_value}")
+            endif()
+        endforeach()
+
+        set_property(TARGET ${target_name} PROPERTY ${property_name} "${filtered_values}")
+    endforeach()
+endfunction()
+
+ve_remove_default_project_bin(app-flash)
+ve_remove_default_project_bin(flash)
+ve_remove_default_project_bin(encrypted-app-flash)
+ve_remove_default_project_bin(encrypted-flash)
+
+esptool_py_flash_target_image(app-flash app "${VE_MAIN_APP_OFFSET}" "${VE_BUILD_DIR}/${VE_PROJECT_BIN}")
+esptool_py_flash_target_image(flash recovery "${VE_RECOVERY_APP_OFFSET}" "${VE_RECOVERY_BIN}" ALWAYS_PLAINTEXT)
+esptool_py_flash_target_image(flash app "${VE_MAIN_APP_OFFSET}" "${VE_BUILD_DIR}/${VE_PROJECT_BIN}")
+
+add_custom_target(ve_recovery_build
+    COMMAND "${CMAKE_COMMAND}" -E copy_if_different
+            "${CMAKE_SOURCE_DIR}/partitions.csv"
+            "${VE_RECOVERY_PARTITIONS_CSV}"
+    COMMAND "${CMAKE_COMMAND}" -E env
+            "IDF_PATH=${VE_IDF_PATH}"
+            "IDF_TOOLS_PATH=${VE_IDF_TOOLS_PATH}"
+            "IDF_PYTHON_ENV_PATH=${VE_PYTHON_ENV_PATH}"
+            "ESP_IDF_VERSION=${VE_ESP_IDF_VERSION}"
+            "ESP_ROM_ELF_DIR=${VE_ESP_ROM_ELF_DIR}"
+            "PATH=${VE_TOOLCHAIN_BIN_DIR}:$ENV{PATH}"
+            "${VE_PYTHON}" "${VE_IDF_PATH}/tools/idf.py"
+            -C "${VE_RECOVERY_PROJECT_DIR}"
+            -D "IDF_TARGET=${VE_IDF_TARGET}"
+            -D "VE_BUILD_WEB=${VE_BUILD_WEB}"
+            reconfigure build
+    BYPRODUCTS "${VE_RECOVERY_BIN}" "${VE_RECOVERY_PARTITIONS_CSV}"
+    WORKING_DIRECTORY "${CMAKE_SOURCE_DIR}"
+    USES_TERMINAL
+    VERBATIM
+)
+
+add_dependencies(ve_recovery_build app)
+add_dependencies(flash ve_recovery_build)

--- a/components/vigilant_engine/include/websocket.h
+++ b/components/vigilant_engine/include/websocket.h
@@ -17,6 +17,9 @@ void websocket_init_log_capture(void);
 // to connected clients.
 esp_err_t websocket_register_handlers(httpd_handle_t server);
 
+// Removes the socket from the websocket client table when HTTPD closes it.
+void websocket_client_closed(int fd);
+
 #ifdef __cplusplus
 }
 #endif

--- a/components/vigilant_engine/src/http_server.c
+++ b/components/vigilant_engine/src/http_server.c
@@ -30,7 +30,7 @@ static const char *TAG = "http_server";
 static httpd_handle_t s_server = NULL;   // unser globaler Server-Handle
 
 #if defined(CONFIG_LWIP_MAX_SOCKETS) && CONFIG_LWIP_MAX_SOCKETS >= 13
-#define VE_HTTPD_MAX_OPEN_SOCKETS 10
+#define VE_HTTPD_MAX_OPEN_SOCKETS 10 // Increase max open sockets if lwip socket amount is increased
 #else
 #define VE_HTTPD_MAX_OPEN_SOCKETS 7
 #endif

--- a/components/vigilant_engine/src/http_server.c
+++ b/components/vigilant_engine/src/http_server.c
@@ -401,7 +401,6 @@ static const httpd_uri_t ctrl = {
 
 static void close_socket_with_ws_cleanup(httpd_handle_t hd, int sockfd)
 {
-    (void)hd;
     websocket_client_closed(sockfd);
     close(sockfd);
 }

--- a/components/vigilant_engine/src/http_server.c
+++ b/components/vigilant_engine/src/http_server.c
@@ -14,6 +14,7 @@
 #include "esp_event.h"
 #include "esp_netif.h"
 #include "esp_tls_crypto.h"
+#include "sdkconfig.h"
 
 #include "ota_http.h"
 #include "vigilant.h"
@@ -27,6 +28,12 @@
 static const char *TAG = "http_server";
 
 static httpd_handle_t s_server = NULL;   // unser globaler Server-Handle
+
+#if defined(CONFIG_LWIP_MAX_SOCKETS) && CONFIG_LWIP_MAX_SOCKETS >= 13
+#define VE_HTTPD_MAX_OPEN_SOCKETS 10
+#else
+#define VE_HTTPD_MAX_OPEN_SOCKETS 7
+#endif
 
 static int hex_nibble(char c)
 {
@@ -392,14 +399,29 @@ static const httpd_uri_t ctrl = {
     .user_ctx  = NULL
 };
 
+static void close_socket_with_ws_cleanup(httpd_handle_t hd, int sockfd)
+{
+    (void)hd;
+    websocket_client_closed(sockfd);
+    close(sockfd);
+}
+
 static httpd_handle_t start_webserver_internal(void)
 {
     httpd_handle_t server = NULL;
     httpd_config_t config = HTTPD_DEFAULT_CONFIG();
     config.max_uri_handlers = 32; // Fixes issue #28: ota_http: Failed to register Vigilant Dashboard GET handler (ESP_ERR_HTTPD_HANDLERS_FULL)
+    config.max_open_sockets = VE_HTTPD_MAX_OPEN_SOCKETS;
+    config.backlog_conn = 8;
     config.lru_purge_enable = true;
+    config.keep_alive_enable = true;
+    config.keep_alive_idle = 30;
+    config.keep_alive_interval = 5;
+    config.keep_alive_count = 3;
+    config.close_fn = close_socket_with_ws_cleanup;
 
-    ESP_LOGI(TAG, "Starting server on port: '%d'", config.server_port);
+    ESP_LOGI(TAG, "Starting server on port: '%d' with %d open sockets",
+             config.server_port, config.max_open_sockets);
     if (httpd_start(&server, &config) == ESP_OK) {
         ESP_LOGI(TAG, "Registering URI handlers");
         httpd_register_uri_handler(server, &hello);
@@ -443,17 +465,6 @@ esp_err_t http_server_stop(void)
 }
 
 #if !CONFIG_IDF_TARGET_LINUX
-static void disconnect_handler(void* arg, esp_event_base_t event_base,
-                               int32_t event_id, void* event_data)
-{
-    (void)arg;
-    (void)event_base;
-    (void)event_id;
-    (void)event_data;
-
-    http_server_stop();
-}
-
 static void connect_handler(void* arg, esp_event_base_t event_base,
                             int32_t event_id, void* event_data)
 {

--- a/components/vigilant_engine/src/vigilant.c
+++ b/components/vigilant_engine/src/vigilant.c
@@ -206,6 +206,7 @@ static esp_err_t wifi_apply_mode(NW_MODE mode,
     ESP_ERROR_CHECK(esp_wifi_start());
 
     if (mode == NW_MODE_STA || mode == NW_MODE_APSTA) {
+        ESP_ERROR_CHECK(esp_wifi_set_ps(WIFI_PS_NONE));
         ESP_ERROR_CHECK(esp_wifi_connect()); // AP-only: NICHT connecten
     }
 

--- a/components/vigilant_engine/src/websocket.c
+++ b/components/vigilant_engine/src/websocket.c
@@ -1,6 +1,7 @@
 #include <string.h>
 #include <stdlib.h>
 #include <stdbool.h>
+#include <stdint.h>
 #include <stdarg.h>
 #include <stdio.h>
 
@@ -17,15 +18,19 @@ static const char *TAG_WS = "ws";
 #define LOG_HISTORY_LINES 200
 #define LOG_LINE_MAX      256
 #define MAX_WS_CLIENTS    8
+#define MAX_PENDING_SENDS_PER_CLIENT 3
 
 typedef struct {
     int fd;
     bool active;
+    uint32_t generation;
+    uint8_t pending_sends;
 } ws_client_t;
 
 typedef struct {
     httpd_handle_t hd;
     int fd;
+    uint32_t generation;
     char *payload;
     size_t len;
 } ws_send_arg_t;
@@ -37,6 +42,7 @@ static char s_log_lines[LOG_HISTORY_LINES][LOG_LINE_MAX];
 static size_t s_log_head = 0;   // next write position
 static size_t s_log_count = 0;  // number of valid lines
 static SemaphoreHandle_t s_ws_mutex = NULL;
+static uint32_t s_next_generation = 1;
 
 static vprintf_like_t s_orig_vprintf = NULL;
 
@@ -53,6 +59,15 @@ static bool ws_client_is_connected(int fd)
     return httpd_ws_get_fd_info(s_server_handle, fd) == HTTPD_WS_CLIENT_WEBSOCKET;
 }
 
+static uint32_t next_generation(void)
+{
+    uint32_t generation = s_next_generation++;
+    if (s_next_generation == 0) {
+        s_next_generation = 1;
+    }
+    return generation;
+}
+
 static void ensure_mutex(void)
 {
     if (!s_ws_mutex) {
@@ -60,16 +75,19 @@ static void ensure_mutex(void)
     }
 }
 
-static void ws_clients_add(int fd)
+static uint32_t ws_clients_add(int fd)
 {
     ensure_mutex();
-    if (!s_ws_mutex) return;
+    if (!s_ws_mutex) return 0;
 
     xSemaphoreTake(s_ws_mutex, portMAX_DELAY);
     for (int i = 0; i < MAX_WS_CLIENTS; ++i) {
         if (s_clients[i].active && s_clients[i].fd == fd) {
+            s_clients[i].generation = next_generation();
+            s_clients[i].pending_sends = 0;
+            uint32_t generation = s_clients[i].generation;
             xSemaphoreGive(s_ws_mutex);
-            return;
+            return generation;
         }
     }
 
@@ -77,26 +95,111 @@ static void ws_clients_add(int fd)
         if (!s_clients[i].active) {
             s_clients[i].fd = fd;
             s_clients[i].active = true;
+            s_clients[i].generation = next_generation();
+            s_clients[i].pending_sends = 0;
+            uint32_t generation = s_clients[i].generation;
             xSemaphoreGive(s_ws_mutex);
-            return;
+            return generation;
         }
     }
     xSemaphoreGive(s_ws_mutex);
 
     ESP_LOGW(TAG_WS, "WS client table full, dropping fd=%d", fd);
+    return 0;
+}
+
+static bool ws_clients_remove_generation(int fd, uint32_t generation)
+{
+    if (!s_ws_mutex) return false;
+    bool removed = false;
+    xSemaphoreTake(s_ws_mutex, portMAX_DELAY);
+    for (int i = 0; i < MAX_WS_CLIENTS; ++i) {
+        if (s_clients[i].active && s_clients[i].fd == fd &&
+            (generation == 0 || s_clients[i].generation == generation)) {
+            s_clients[i].active = false;
+            s_clients[i].fd = -1;
+            s_clients[i].generation = 0;
+            s_clients[i].pending_sends = 0;
+            removed = true;
+        }
+    }
+    xSemaphoreGive(s_ws_mutex);
+    return removed;
 }
 
 static void ws_clients_remove(int fd)
 {
-    if (!s_ws_mutex) return;
+    (void)ws_clients_remove_generation(fd, 0);
+}
+
+static bool ws_clients_mark_send_queued(int fd, uint32_t *generation)
+{
+    ensure_mutex();
+    if (!s_ws_mutex) return false;
+
+    bool queued = false;
     xSemaphoreTake(s_ws_mutex, portMAX_DELAY);
     for (int i = 0; i < MAX_WS_CLIENTS; ++i) {
         if (s_clients[i].active && s_clients[i].fd == fd) {
-            s_clients[i].active = false;
-            s_clients[i].fd = -1;
+            if (s_clients[i].pending_sends < MAX_PENDING_SENDS_PER_CLIENT) {
+                s_clients[i].pending_sends++;
+                *generation = s_clients[i].generation;
+                queued = true;
+            }
+            break;
         }
     }
     xSemaphoreGive(s_ws_mutex);
+    return queued;
+}
+
+static void ws_clients_mark_send_done(int fd, uint32_t generation)
+{
+    if (!s_ws_mutex) return;
+
+    xSemaphoreTake(s_ws_mutex, portMAX_DELAY);
+    for (int i = 0; i < MAX_WS_CLIENTS; ++i) {
+        if (s_clients[i].active && s_clients[i].fd == fd &&
+            s_clients[i].generation == generation) {
+            if (s_clients[i].pending_sends > 0) {
+                s_clients[i].pending_sends--;
+            }
+            break;
+        }
+    }
+    xSemaphoreGive(s_ws_mutex);
+}
+
+static bool ws_client_generation_is_current(int fd, uint32_t generation)
+{
+    if (!s_ws_mutex) return false;
+
+    bool current = false;
+    xSemaphoreTake(s_ws_mutex, portMAX_DELAY);
+    for (int i = 0; i < MAX_WS_CLIENTS; ++i) {
+        if (s_clients[i].active && s_clients[i].fd == fd &&
+            s_clients[i].generation == generation) {
+            current = true;
+            break;
+        }
+    }
+    xSemaphoreGive(s_ws_mutex);
+    return current;
+}
+
+static void ws_trigger_close_if_current(int fd, uint32_t generation)
+{
+    if (ws_clients_remove_generation(fd, generation) && s_server_handle) {
+        httpd_sess_trigger_close(s_server_handle, fd);
+    }
+}
+
+static bool should_stream_log_line(const char *line)
+{
+    // Avoid feeding HTTPD/WebSocket transport errors back into the WebSocket
+    // that just failed. They still print on UART and remain in the history.
+    return !strstr(line, " httpd_txrx:") &&
+           !strstr(line, " httpd_ws:");
 }
 
 static void append_log_line(const char *line)
@@ -120,8 +223,10 @@ static void ws_send_text_async(void *arg)
     ws_send_arg_t *a = (ws_send_arg_t *)arg;
     if (!a) return;
 
-    if (!ws_client_is_connected(a->fd)) {
-        ws_clients_remove(a->fd);
+    if (!ws_client_generation_is_current(a->fd, a->generation) ||
+        !ws_client_is_connected(a->fd)) {
+        ws_clients_mark_send_done(a->fd, a->generation);
+        ws_trigger_close_if_current(a->fd, a->generation);
         free(a->payload);
         free(a);
         return;
@@ -136,8 +241,9 @@ static void ws_send_text_async(void *arg)
     };
 
     esp_err_t ret = httpd_ws_send_frame_async(a->hd, a->fd, &frame);
+    ws_clients_mark_send_done(a->fd, a->generation);
     if (ret != ESP_OK) {
-        ws_clients_remove(a->fd);
+        ws_trigger_close_if_current(a->fd, a->generation);
     }
 
     free(a->payload);
@@ -150,16 +256,23 @@ static esp_err_t ws_queue_send_text(int fd, const char *text)
         return ESP_ERR_INVALID_STATE;
     }
 
+    uint32_t generation = 0;
+    if (!ws_clients_mark_send_queued(fd, &generation)) {
+        return ESP_ERR_INVALID_STATE;
+    }
+
     ws_send_arg_t *arg = (ws_send_arg_t *)malloc(sizeof(ws_send_arg_t));
     char *dup = strdup(text);
     if (!arg || !dup) {
         free(arg);
         free(dup);
+        ws_clients_mark_send_done(fd, generation);
         return ESP_ERR_NO_MEM;
     }
 
     arg->hd = s_server_handle;
     arg->fd = fd;
+    arg->generation = generation;
     arg->payload = dup;
     arg->len = strlen(dup);
 
@@ -167,7 +280,7 @@ static esp_err_t ws_queue_send_text(int fd, const char *text)
     if (ret != ESP_OK) {
         free(arg->payload);
         free(arg);
-        ws_clients_remove(fd);
+        ws_clients_mark_send_done(fd, generation);
     }
     return ret;
 }
@@ -222,7 +335,9 @@ static int websocket_log_vprintf(const char *fmt, va_list ap)
     }
 
     append_log_line(line);
-    broadcast_log_line(line);
+    if (should_stream_log_line(line)) {
+        broadcast_log_line(line);
+    }
 
     if (s_orig_vprintf) {
         return s_orig_vprintf(fmt, ap);
@@ -283,7 +398,11 @@ static esp_err_t websocket_handler(httpd_req_t *req)
 
     // Handshake call
     if (req->method == HTTP_GET) {
-        ws_clients_add(fd);
+        uint32_t generation = ws_clients_add(fd);
+        if (generation == 0) {
+            httpd_sess_trigger_close(req->handle, fd);
+            return ESP_FAIL;
+        }
         send_log_history(fd);
         ESP_LOGI(TAG_WS, "WebSocket client connected: fd=%d", fd);
         return ESP_OK;
@@ -370,6 +489,11 @@ void websocket_init_log_capture(void)
 
     s_orig_vprintf = esp_log_set_vprintf(websocket_log_vprintf);
     ensure_mutex();
+}
+
+void websocket_client_closed(int fd)
+{
+    ws_clients_remove(fd);
 }
 
 /**

--- a/components/vigilant_engine/src/websocket.c
+++ b/components/vigilant_engine/src/websocket.c
@@ -62,17 +62,15 @@ static bool ws_client_is_connected(int fd)
 static uint32_t next_generation(void)
 {
     uint32_t generation = s_next_generation++;
-    if (s_next_generation == 0) {
-        s_next_generation = 1;
-    }
     return generation;
 }
 
-static void ensure_mutex(void)
+static SemaphoreHandle_t ensure_mutex(void)
 {
     if (!s_ws_mutex) {
         s_ws_mutex = xSemaphoreCreateMutex();
     }
+    return s_ws_mutex; // returns NULL on failure, but we check for that in callers
 }
 
 static uint32_t ws_clients_add(int fd)

--- a/components/vigilant_engine/src/websocket.c
+++ b/components/vigilant_engine/src/websocket.c
@@ -132,7 +132,8 @@ static void ws_clients_remove(int fd)
 
 static bool ws_clients_mark_send_queued(int fd, uint32_t *generation)
 {
-    ensure_mutex();
+    SemaphoreHandle_t mutex = ensure_mutex();
+    if (!mutex) return false;
     if (!s_ws_mutex) return false;
 
     bool queued = false;

--- a/main/main.c
+++ b/main/main.c
@@ -14,24 +14,4 @@ void app_main(void)
         .network_mode = NW_MODE_APSTA
     };
     ESP_ERROR_CHECK(vigilant_init(VgConfig));
-
-    VigilantI2CDevice device = {
-        .address = 0x18,
-        .whoami_reg = 0x0F,
-        .expected_whoami = 0x32,
-        .handle = NULL,
-    };
-
-    ESP_ERROR_CHECK(vigilant_i2c_add_device(&device));
-    esp_err_t i2cerr = vigilant_i2c_whoami_check(&device); // WHOAMI check
-    if (i2cerr != ESP_OK) {
-        status_led_set_state(STATUS_STATE_ERROR);
-        ESP_LOGE("app_main", "I2C WHOAMI check failed: %s", esp_err_to_name(i2cerr));
-    } else {
-        status_led_set_state(STATUS_STATE_INFO);
-        ESP_LOGI("app_main", "I2C WHOAMI check succeeded");
-        uint8_t value = 0;
-        ESP_ERROR_CHECK(vigilant_i2c_read_reg8(&device, 0x27, &value)); // Reading a register (e.g. control register)
-        ESP_LOGI("app_main i2c test", "reg 0x27 value: 0x%02X", value);
-    }
 }

--- a/sdkconfig.defaults
+++ b/sdkconfig.defaults
@@ -37,3 +37,8 @@ CONFIG_HTTPD_SERVER_EVENT_POST_TIMEOUT=2000
 #To enable logging while using the timer
 #Weirdly also fixes the serial time out?
 CONFIG_FREERTOS_TIMER_TASK_STACK_DEPTH=4096
+
+#
+# LWIP
+#
+CONFIG_LWIP_MAX_SOCKETS=13

--- a/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
+++ b/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
@@ -265,6 +265,7 @@ const reconnectAttempts = ref(0);
 const pingTimer = ref<number | null>(null);
 const lastHeartbeat = ref<number>(0);
 const connectionOk = ref(false);
+let consoleScrollQueued = false;
 
 const consoleHtml = computed(() =>
   lines.value
@@ -491,10 +492,24 @@ const scrollConsoleToBottom = () => {
   }
 };
 
+function scheduleConsoleScroll() {
+  if (consoleScrollQueued) return;
+  consoleScrollQueued = true;
+  nextTick().then(() => {
+    consoleScrollQueued = false;
+    scrollConsoleToBottom();
+  });
+}
+
+function appendLogLines(newLines: string[]) {
+  if (!newLines.length) return;
+  lines.value = [...lines.value, ...newLines].slice(-MAX_LOG_LINES);
+  scheduleConsoleScroll();
+}
+
 async function pushLine(msg: string) {
-  lines.value = [...lines.value, msg].slice(-MAX_LOG_LINES);
+  appendLogLines([msg]);
   await nextTick();
-  scrollConsoleToBottom();
 }
 
 async function log(msg: string) {
@@ -514,15 +529,13 @@ function handleLogPayload(raw: unknown) {
       payload.lines.filter((line): line is string => typeof line === "string")
     );
     lines.value = normalized.slice(-MAX_LOG_LINES);
-    nextTick().then(scrollConsoleToBottom);
+    scheduleConsoleScroll();
     return;
   }
 
   if (payload.type === "log" && typeof payload.line === "string") {
     const merged = splitAndNormalize(payload.line);
-    for (const l of merged) {
-      pushLine(l);
-    }
+    appendLogLines(merged);
   }
 }
 
@@ -533,7 +546,9 @@ function clearPingTimer() {
   }
 }
 
-function scheduleReconnect() {
+function scheduleReconnect(ws: WebSocket) {
+  if (socket.value !== ws) return;
+
   if (reconnectHandle.value !== null) return;
   socket.value = null;
   connectionOk.value = false;
@@ -564,11 +579,21 @@ function connectLogStream() {
   socket.value = ws;
 
   ws.addEventListener("open", () => {
+    if (socket.value !== ws) {
+      try { ws.close(); } catch (_) {}
+      return;
+    }
+
     reconnectAttempts.value = 0;
     lastHeartbeat.value = performance.now();
     connectionOk.value = true;
 
-    pingTimer.value = window.setInterval(() => {
+    const timer = window.setInterval(() => {
+      if (socket.value !== ws) {
+        clearInterval(timer);
+        return;
+      }
+
       if (ws.readyState !== WebSocket.OPEN) {
         return;
       }
@@ -582,9 +607,11 @@ function connectLogStream() {
 
       try { ws.send('{"type":"ping"}'); } catch (_) {}
     }, PING_INTERVAL_MS);
+    pingTimer.value = timer;
   });
 
   ws.addEventListener("message", (event) => {
+    if (socket.value !== ws) return;
     if (typeof event.data !== "string") return;
     lastHeartbeat.value = performance.now();
     connectionOk.value = true;
@@ -595,10 +622,11 @@ function connectLogStream() {
     }
   });
 
-  ws.addEventListener("close", scheduleReconnect);
+  ws.addEventListener("close", () => scheduleReconnect(ws));
   ws.addEventListener("error", () => {
+    if (socket.value !== ws) return;
     connectionOk.value = false;
-    scheduleReconnect();
+    scheduleReconnect(ws);
     try { ws.close(); } catch (_) {}
   });
 }

--- a/vigilant-engine-recovery/CMakeLists.txt
+++ b/vigilant-engine-recovery/CMakeLists.txt
@@ -1,28 +1,21 @@
-# The following lines of boilerplate have to be in your project's
-# CMakeLists in this exact order for cmake to work correctly
 cmake_minimum_required(VERSION 3.16)
 
 include($ENV{IDF_PATH}/tools/cmake/project.cmake)
 # "Trim" the build. Include the minimal set of components, main, and anything it depends on.
 idf_build_set_property(MINIMAL_BUILD ON)
-project(vigilant-engine-recovery)
 
 # ---- Web UI (Vite) build integration ----
 option(VE_BUILD_WEB "Build Vite UI before compiling firmware" ON)
 
+get_filename_component(VE_REPO_ROOT "${CMAKE_SOURCE_DIR}/.." ABSOLUTE)
+set(VE_NODE_ROOT_DIR "${VE_REPO_ROOT}")
+set(VE_WEB_DIR "${VE_REPO_ROOT}/vigilant-engine-frontend")
+set(VE_RECOVERY_HTML "${VE_REPO_ROOT}/build/static/recovery/index.html")
+
+idf_build_set_property(VE_BUILD_WEB "${VE_BUILD_WEB}")
+idf_build_set_property(VE_RECOVERY_HTML "${VE_RECOVERY_HTML}")
+
 if(VE_BUILD_WEB)
-  find_program(NPM_EXECUTABLE npm)
-  if(NOT NPM_EXECUTABLE)
-    message(FATAL_ERROR "npm not found. Install Node.js/npm or set VE_BUILD_WEB=OFF.")
-  endif()
-
-  get_filename_component(VE_REPO_ROOT "${CMAKE_SOURCE_DIR}/.." ABSOLUTE)
-  set(VE_NODE_ROOT_DIR "${VE_REPO_ROOT}")
-  set(VE_WEB_DIR "${VE_REPO_ROOT}/vigilant-engine-frontend")
-
-  set(VE_OUT_RECOVERY "${CMAKE_SOURCE_DIR}/main/static/index.html")
-  set(VE_WEB_STAMP "${CMAKE_BINARY_DIR}/ve_web_build.stamp")
-
   file(GLOB_RECURSE VE_WEB_SOURCES CONFIGURE_DEPENDS
     "${VE_NODE_ROOT_DIR}/package.json"
     "${VE_NODE_ROOT_DIR}/package-lock.json"
@@ -38,20 +31,26 @@ if(VE_BUILD_WEB)
     "${VE_WEB_DIR}/src/*"
   )
 
+  find_program(NPM_EXECUTABLE npm)
+  if(NOT NPM_EXECUTABLE)
+    message(FATAL_ERROR "npm not found. Install Node.js/npm or set VE_BUILD_WEB=OFF.")
+  endif()
+
   add_custom_command(
-    OUTPUT "${VE_WEB_STAMP}"
+    OUTPUT "${VE_RECOVERY_HTML}"
 
     COMMAND "${CMAKE_COMMAND}" -E chdir "${VE_NODE_ROOT_DIR}" "${NPM_EXECUTABLE}" install
     COMMAND "${CMAKE_COMMAND}" -E chdir "${VE_WEB_DIR}" "${NPM_EXECUTABLE}" install
     COMMAND "${CMAKE_COMMAND}" -E chdir "${VE_WEB_DIR}" "${NPM_EXECUTABLE}" run build:recovery
 
-    COMMAND "${CMAKE_COMMAND}" -E touch "${VE_WEB_STAMP}"
-
     DEPENDS ${VE_WEB_SOURCES}
-    BYPRODUCTS "${VE_OUT_RECOVERY}"
     COMMENT "Building Vite UI (recovery)"
     VERBATIM
   )
 
-  add_custom_target(ve_web ALL DEPENDS "${VE_WEB_STAMP}")
+  add_custom_target(ve_web ALL DEPENDS "${VE_RECOVERY_HTML}")
 endif()
+
+# Keep project() after ve_web so the main component can depend on the generated
+# build/static/recovery/index.html before ESP-IDF creates the embed rule.
+project(vigilant-engine-recovery)

--- a/vigilant-engine-recovery/main/CMakeLists.txt
+++ b/vigilant-engine-recovery/main/CMakeLists.txt
@@ -1,8 +1,23 @@
+idf_build_get_property(recovery_html VE_RECOVERY_HTML)
+idf_build_get_property(ve_build_web VE_BUILD_WEB)
+
+if(NOT recovery_html)
+    idf_build_get_property(build_dir BUILD_DIR)
+    set(recovery_html "${build_dir}/static/recovery/index.html")
+endif()
+
+if(NOT ve_build_web AND NOT EXISTS "${recovery_html}")
+    message(FATAL_ERROR
+        "Recovery UI HTML is missing and VE_BUILD_WEB=OFF.\n"
+        "Expected prebuilt file at ${recovery_html}."
+    )
+endif()
+
 idf_component_register(
     SRCS "recovery_app.c"
     INCLUDE_DIRS "."
     EMBED_FILES 
-        "static/index.html"
+        "${recovery_html}"
     REQUIRES esp_wifi esp_netif esp_event nvs_flash esp_http_server app_update esp_partition
 )
 


### PR DESCRIPTION
This pull request introduces several improvements and fixes to both the firmware and frontend, as well as the build process

Websocket: WebSocket stability, log streaming, and build configuration. The most significant changes are the introduction of robust WebSocket client tracking and flow control, improved handling of log streaming to the frontend

Also, the cmake now builds and flashes both the recovery and main, essentially removing the need for `flash.py`

The main reason for the webserver slowness probably was the power save mode.



# blablabla ai summary:


**WebSocket stability and flow control improvements:**

* Refactored WebSocket client management to use a generation-based tracking system, preventing stale or duplicate client entries and ensuring that only active clients receive messages. Introduced per-client flow control to limit the number of pending sends and avoid overwhelming the system. Added functions to clean up client state when connections are closed, and improved async send logic to handle disconnects and errors more gracefully (`components/vigilant_engine/src/websocket.c`, `components/vigilant_engine/include/websocket.h`) [[1]](diffhunk://#diff-c240a22b202ae0af843e4873190da56e8256b4f48961bddd3b437cfeb6383e3eR21-R33) [[2]](diffhunk://#diff-c240a22b202ae0af843e4873190da56e8256b4f48961bddd3b437cfeb6383e3eR62-R202) [[3]](diffhunk://#diff-c240a22b202ae0af843e4873190da56e8256b4f48961bddd3b437cfeb6383e3eL123-R229) [[4]](diffhunk://#diff-c240a22b202ae0af843e4873190da56e8256b4f48961bddd3b437cfeb6383e3eR244-R246) [[5]](diffhunk://#diff-c240a22b202ae0af843e4873190da56e8256b4f48961bddd3b437cfeb6383e3eR259-R283) [[6]](diffhunk://#diff-c240a22b202ae0af843e4873190da56e8256b4f48961bddd3b437cfeb6383e3eR338-R340) [[7]](diffhunk://#diff-c240a22b202ae0af843e4873190da56e8256b4f48961bddd3b437cfeb6383e3eL286-R405) [[8]](diffhunk://#diff-c240a22b202ae0af843e4873190da56e8256b4f48961bddd3b437cfeb6383e3eR494-R498) [[9]](diffhunk://#diff-0386d3ed9f26272c96f8640ba94392d6d1d1b84258439e0480cf5a0fc444c0b3R20-R22).

* Improved log streaming by filtering out internal HTTPD/WebSocket errors from being broadcast back to clients, reducing noise and potential feedback loops in the log output (`components/vigilant_engine/src/websocket.c`).

**HTTP server configuration and robustness:**

* Increased the maximum number of open sockets and made this configurable based on `CONFIG_LWIP_MAX_SOCKETS`. Added keep-alive options, connection backlog, and a custom close function to ensure proper cleanup of WebSocket clients when HTTPD closes sockets. Removed unused disconnect handler (`components/vigilant_engine/src/http_server.c`, `sdkconfig.defaults`) [[1]](diffhunk://#diff-1848c2305024f39f33d860610357e22507dea5870958da4775bdcd9fb53888f6R32-R37) [[2]](diffhunk://#diff-1848c2305024f39f33d860610357e22507dea5870958da4775bdcd9fb53888f6R402-R424) [[3]](diffhunk://#diff-1848c2305024f39f33d860610357e22507dea5870958da4775bdcd9fb53888f6L446-L456) [[4]](diffhunk://#diff-828575c709a84e0dfe49845ee9030bcc01f12e9220029d91761990595de011a1R40-R44).

**Build system and CI improvements:**

* Enhanced the CMake build system to better manage firmware and recovery images, including dynamic partition offset detection, environment variable handling, and dependencies between application and recovery builds.

* Improved frontend log handling by batching log line updates and scheduling scrolls to the bottom only when needed, reducing unnecessary DOM updates and improving performance (`vigilant-engine-frontend/src/vigilant/VigilantApp.vue`) [[1]](diffhunk://#diff-f2a0ec169a013e8bfe89419ae29ff13b2b96efe08deadfea1a3a2156091038a4R268) [[2]](diffhunk://#diff-f2a0ec169a013e8bfe89419ae29ff13b2b96efe08deadfea1a3a2156091038a4R495-L497).

**Other fixes and cleanup:**

* Ensured WiFi is set to no power-save mode in station or APSTA modes for improved connectivity (`components/vigilant_engine/src/vigilant.c`).
* Removed test I2C device code from `app_main` for a cleaner main entry point (`main/main.c`).
* Included missing `sdkconfig.h` header in HTTP server code to resolve build issues (`components/vigilant_engine/src/http_server.c`).