### PR TITLE
Git hash is now embedded into frontend, issue #66

### DIFF
--- a/vigilant-engine-frontend/src/recovery/RecoveryApp.vue
+++ b/vigilant-engine-frontend/src/recovery/RecoveryApp.vue
@@ -2,6 +2,9 @@
   <div class="container">
     <h2>⚡ Vigilant Engine</h2>
     <div class="subtitle">⚠️ Recovery Mode</div>
+    <div class="build-chip" :data-git-hash="buildGitHash" :title="buildGitHashTitle">
+      git {{ buildGitHashShort }}
+    </div>
 
     <label for="f" class="file-input">
       <span>{{ fileLabel }}</span>
@@ -19,6 +22,7 @@
 
 <script setup lang="ts">
 import { computed, ref } from "vue";
+import { buildGitHash, buildGitHashShort, buildGitHashTitle } from "../shared/buildInfo";
 
 const fileEl = ref<HTMLInputElement | null>(null);
 const picked = ref<File | null>(null);
@@ -90,8 +94,23 @@ h2 {
 .subtitle {
   font-size: 0.875rem;
   color: #ef4444;
-  margin-bottom: 24px;
+  margin-bottom: 10px;
   font-weight: 600;
+}
+
+.build-chip {
+  display: inline-flex;
+  align-items: center;
+  width: fit-content;
+  padding: 6px 10px;
+  margin-bottom: 24px;
+  border: 1px solid #1f2937;
+  border-radius: 999px;
+  background: rgba(13, 17, 23, 0.78);
+  color: #9ca3af;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0;
 }
 
 .file-input {

--- a/vigilant-engine-frontend/src/shared/buildInfo.ts
+++ b/vigilant-engine-frontend/src/shared/buildInfo.ts
@@ -1,0 +1,12 @@
+declare const __VIGILANT_ENGINE_GIT_HASH__: string | undefined;
+
+const rawGitHash =
+  typeof __VIGILANT_ENGINE_GIT_HASH__ === "string"
+    ? __VIGILANT_ENGINE_GIT_HASH__
+    : "unknown";
+
+export const buildGitHash = rawGitHash;
+export const buildGitHashShort =
+  rawGitHash === "unknown" ? "unknown" : rawGitHash.slice(0, 12);
+export const buildGitHashTitle =
+  rawGitHash === "unknown" ? "Build commit unavailable" : `Build commit ${rawGitHash}`;

--- a/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
+++ b/vigilant-engine-frontend/src/vigilant/VigilantApp.vue
@@ -11,6 +11,9 @@
         </div>
         <div class="status">{{ statusText }}</div>
       </div>
+      <div class="build-chip" :data-git-hash="buildGitHash" :title="buildGitHashTitle">
+        git {{ buildGitHashShort }}
+      </div>
     </header>
 
     <main class="workspace">
@@ -204,6 +207,7 @@
 
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, onMounted, ref, watch } from "vue";
+import { buildGitHash, buildGitHashShort, buildGitHashTitle } from "../shared/buildInfo";
 
 type ProtocolId = "i2c" | "spi" | "canfd" | "wifi";
 type DeviceState = "added" | "detected";
@@ -699,6 +703,7 @@ async function proceed() {
 .tab,
 .btn-danger,
 .btn-primary,
+.build-chip,
 .connected-device,
 .protocol-pill,
 .pill,
@@ -800,6 +805,18 @@ h1 {
 }
 
 .title-block { display: flex; flex-direction: column; gap: 4px; }
+
+.build-chip {
+  flex-shrink: 0;
+  padding: 6px 10px;
+  border: 1px solid #1f2937;
+  border-radius: 999px;
+  background: rgba(13, 17, 23, 0.78);
+  color: #9ca3af;
+  font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, "Liberation Mono", monospace;
+  font-size: 0.75rem;
+  letter-spacing: 0;
+}
 
 .workspace {
   display: flex;

--- a/vigilant-engine-frontend/vite.config.js
+++ b/vigilant-engine-frontend/vite.config.js
@@ -1,11 +1,35 @@
 import { defineConfig } from "vite";
 import vue from "@vitejs/plugin-vue";
 import { viteSingleFile } from "vite-plugin-singlefile";
+import { execSync } from "node:child_process";
 import path from "node:path";
+
+function getGitHash() {
+  const envHash =
+    process.env.VITE_GIT_HASH ??
+    process.env.GIT_HASH ??
+    process.env.GITHUB_SHA ??
+    process.env.COMMIT_SHA;
+
+  if (envHash?.trim()) {
+    return envHash.trim();
+  }
+
+  try {
+    return execSync("git rev-parse HEAD", {
+      cwd: __dirname,
+      encoding: "utf8",
+      stdio: ["ignore", "pipe", "ignore"],
+    }).trim();
+  } catch {
+    return "unknown";
+  }
+}
 
 export default defineConfig(({ mode }) => {
   const isVigilant = mode === "vigilant";
   const isRecovery = mode === "recovery";
+  const gitHash = getGitHash();
 
   // Decide which HTML entry to open in dev server
   const devEntry = isVigilant
@@ -34,6 +58,9 @@ export default defineConfig(({ mode }) => {
     // MPA avoids history-fallback forcing /index.html and lets us open either page directly
     appType: "mpa",
     plugins: [vue(), viteSingleFile()],
+    define: {
+      __VIGILANT_ENGINE_GIT_HASH__: JSON.stringify(gitHash),
+    },
     server: {
       open: devEntry,
     },


### PR DESCRIPTION
This pull request introduces a build-time mechanism to display the current Git commit hash in both the main and recovery UIs, making it easier to identify the exact build version in use. The implementation includes a new shared module for build info, updates to the UI components to show the Git hash, and changes to the build configuration to inject the commit hash.

<img width="1916" height="990" alt="image" src="https://github.com/user-attachments/assets/a50f0afa-7399-41c3-be7f-e3a0463f17dd" />
 
Closes #66 