### PR TITLE
Update pre-commit versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,7 +18,7 @@ repos:
   - id: remove-crlf
 
 - repo: https://github.com/astral-sh/ruff-pre-commit
-  rev: v0.15.12
+  rev: v0.15.17
   hooks:
   - id: ruff
     args: [ --select, I, --fix ]


### PR DESCRIPTION
This PR updates the pre-commit hook versions (Ruff v0.15.12 -> v0.15.17).