### PR TITLE
feature/autostart

### DIFF
--- a/.github/workflows/esp-build.yml
+++ b/.github/workflows/esp-build.yml
@@ -76,4 +76,5 @@ jobs:
           idf.py \
             -DVE_BUILD_WEB=OFF \
             -DVE_VIGILANT_HTML="${GITHUB_WORKSPACE}/.ci-artifacts/frontend/vigilant.html" \
+            -DVE_RECOVERY_HTML="${GITHUB_WORKSPACE}/.ci-artifacts/frontend/recovery.html" \
             build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ add_compile_options("-Werror")
 # Allow CI to supply prebuilt web assets while keeping local builds automatic.
 option(VE_BUILD_WEB "Build the Vigilant UI with npm when the embedded HTML is missing" ON)
 set(VE_VIGILANT_HTML "" CACHE FILEPATH "Path to a prebuilt vigilant.html file for firmware builds")
+set(VE_RECOVERY_HTML "" CACHE FILEPATH "Path to a prebuilt recovery.html file for recovery firmware builds")
 
 if(NOT DEFINED ENV{IDF_PATH} OR "$ENV{IDF_PATH}" STREQUAL "")
   message(FATAL_ERROR
@@ -21,6 +22,7 @@ idf_build_set_property(MINIMAL_BUILD ON)
 # build properties so component logic can still read these values during that pass.
 idf_build_set_property(VE_BUILD_WEB "${VE_BUILD_WEB}")
 idf_build_set_property(VE_VIGILANT_HTML "${VE_VIGILANT_HTML}")
+idf_build_set_property(VE_RECOVERY_HTML "${VE_RECOVERY_HTML}")
 project(vigilant-engine)
 
 idf_build_get_property(VE_BUILD_DIR BUILD_DIR)
@@ -118,6 +120,7 @@ add_custom_target(ve_recovery_build ALL
             "-DSDKCONFIG=${VE_RECOVERY_SDKCONFIG}"
             "-DSDKCONFIG_DEFAULTS=${VE_RECOVERY_PROJECT_DIR}/sdkconfig.defaults"
             "-DVE_BUILD_WEB=${VE_BUILD_WEB}"
+            "-DVE_RECOVERY_HTML=${VE_RECOVERY_HTML}"
     COMMAND "${CMAKE_COMMAND}" -E env
             ${VE_RECOVERY_BUILD_ENV}
             "${CMAKE_COMMAND}" --build "${VE_RECOVERY_BUILD_DIR}"

--- a/vigilant-engine-recovery/CMakeLists.txt
+++ b/vigilant-engine-recovery/CMakeLists.txt
@@ -16,11 +16,12 @@ idf_build_set_property(MINIMAL_BUILD ON)
 
 # ---- Web UI (Vite) build integration ----
 option(VE_BUILD_WEB "Build Vite UI before compiling firmware" ON)
+set(VE_RECOVERY_HTML "" CACHE FILEPATH "Path to a prebuilt recovery HTML file")
 
 get_filename_component(VE_REPO_ROOT "${CMAKE_SOURCE_DIR}/.." ABSOLUTE)
 set(VE_NODE_ROOT_DIR "${VE_REPO_ROOT}")
 set(VE_WEB_DIR "${VE_REPO_ROOT}/vigilant-engine-frontend")
-set(VE_RECOVERY_HTML "${VE_REPO_ROOT}/build/static/recovery/index.html")
+set(VE_RECOVERY_HTML_FROM_BUILD "${VE_REPO_ROOT}/build/static/recovery/index.html")
 set(VE_ROOT_PARTITIONS_CSV "${VE_REPO_ROOT}/partitions.csv")
 set(VE_RECOVERY_PARTITIONS_CSV "${CMAKE_SOURCE_DIR}/partitions.csv")
 
@@ -29,9 +30,33 @@ if(EXISTS "${VE_ROOT_PARTITIONS_CSV}")
 endif()
 
 idf_build_set_property(VE_BUILD_WEB "${VE_BUILD_WEB}")
-idf_build_set_property(VE_RECOVERY_HTML "${VE_RECOVERY_HTML}")
 
-if(VE_BUILD_WEB)
+if(VE_RECOVERY_HTML)
+  if(IS_ABSOLUTE "${VE_RECOVERY_HTML}")
+    set(ve_recovery_html_source "${VE_RECOVERY_HTML}")
+  else()
+    get_filename_component(ve_recovery_html_source "${VE_REPO_ROOT}/${VE_RECOVERY_HTML}" ABSOLUTE)
+  endif()
+
+  if(NOT EXISTS "${ve_recovery_html_source}")
+    message(FATAL_ERROR
+      "VE_RECOVERY_HTML points to '${ve_recovery_html_source}', but that file does not exist."
+    )
+  endif()
+
+  set(ve_recovery_html "${CMAKE_BINARY_DIR}/static/recovery/index.html")
+  get_filename_component(ve_recovery_html_dir "${ve_recovery_html}" DIRECTORY)
+  file(MAKE_DIRECTORY "${ve_recovery_html_dir}")
+  configure_file("${ve_recovery_html_source}" "${ve_recovery_html}" COPYONLY)
+
+  message(STATUS "Using prebuilt Recovery UI from ${ve_recovery_html_source}")
+else()
+  set(ve_recovery_html "${VE_RECOVERY_HTML_FROM_BUILD}")
+endif()
+
+idf_build_set_property(VE_RECOVERY_HTML "${ve_recovery_html}")
+
+if(VE_BUILD_WEB AND NOT VE_RECOVERY_HTML)
   file(GLOB_RECURSE VE_WEB_SOURCES CONFIGURE_DEPENDS
     "${VE_NODE_ROOT_DIR}/package.json"
     "${VE_NODE_ROOT_DIR}/package-lock.json"
@@ -53,7 +78,7 @@ if(VE_BUILD_WEB)
   endif()
 
   add_custom_command(
-    OUTPUT "${VE_RECOVERY_HTML}"
+    OUTPUT "${ve_recovery_html}"
 
     COMMAND "${CMAKE_COMMAND}" -E chdir "${VE_NODE_ROOT_DIR}" "${NPM_EXECUTABLE}" install
     COMMAND "${CMAKE_COMMAND}" -E chdir "${VE_WEB_DIR}" "${NPM_EXECUTABLE}" install
@@ -64,7 +89,7 @@ if(VE_BUILD_WEB)
     VERBATIM
   )
 
-  add_custom_target(ve_web ALL DEPENDS "${VE_RECOVERY_HTML}")
+  add_custom_target(ve_web ALL DEPENDS "${ve_recovery_html}")
 endif()
 
 # Keep project() after ve_web so the main component can depend on the generated

--- a/vigilant-engine-recovery/main/recovery_app.c
+++ b/vigilant-engine-recovery/main/recovery_app.c
@@ -258,6 +258,19 @@ static void wifi_init_softap(void) {
 }
 
 void app_main(void) {
+    /*
+
+    IMPORTANT:
+    A note to auto booting when we implement boot flags to determine if we are
+    in flight or not, etc.
+
+    We might want to skip the recovery mode if we are in flight or if we have a
+    valid boot flag set. This ensures we dont wait a long time for a device to
+    connect, when we know no device will connect in flight. Furthermore, this
+    allows for quickly recovering the device in flight.
+
+    */
+
     // NVS required for WiFi on many setups
     esp_err_t nvs = nvs_flash_init();
     if (nvs == ESP_ERR_NVS_NO_FREE_PAGES ||

--- a/vigilant-engine-recovery/main/recovery_app.c
+++ b/vigilant-engine-recovery/main/recovery_app.c
@@ -43,32 +43,34 @@ static const esp_partition_t* find_ota0_partition(void) {
     return p;
 }
 
-static esp_err_t boot_post_handler(httpd_req_t* req) {
+static esp_err_t boot_ota0_partition(void) {
     const esp_partition_t* ota0 = find_ota0_partition();
     if (!ota0) {
         ESP_LOGE(TAG, "ota_0 partition not found");
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
-                            "ota_0 not found");
-        return ESP_FAIL;
+        return ESP_ERR_NOT_FOUND;
     }
 
     esp_err_t err = esp_ota_set_boot_partition(ota0);
     if (err != ESP_OK) {
         ESP_LOGE(TAG, "esp_ota_set_boot_partition failed: %s",
                  esp_err_to_name(err));
-        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
-                            "set_boot_partition failed");
-        return ESP_FAIL;
+        return err;
     }
 
     ESP_LOGI(TAG, "Boot partition set to ota_0. Rebooting…");
-
-    httpd_resp_set_type(req, "text/plain");
-    httpd_resp_sendstr(req, "OK. Rebooting to ota_0...\n");
-
     vTaskDelay(pdMS_TO_TICKS(250));
     esp_restart();
-    return ESP_OK;
+    return ESP_OK;  // should never reach here
+}
+
+static esp_err_t boot_post_handler(httpd_req_t* req) {
+    esp_err_t boot_err = boot_ota0_partition();
+    if (boot_err != ESP_OK) {
+        httpd_resp_send_err(req, HTTPD_500_INTERNAL_SERVER_ERROR,
+                            "Failed to set boot partition");
+        return boot_err;
+    }
+    return ESP_OK;  // should never reach here
 }
 
 static esp_err_t ota_post_handler(httpd_req_t* req) {
@@ -273,8 +275,27 @@ void app_main(void) {
     wifi_init_softap();
     start_http_server();
 
-    // Keep main task alive
-    while (true) {
+    bool device_connected = false;
+    for (size_t i = 0; i < 7 && !device_connected;
+         i++)  // wait 7 seconds for a device to connect to the AP
+    {
+        ESP_LOGI(TAG, "Waiting for device to connect to AP... (%d/7)", i + 1);
         vTaskDelay(pdMS_TO_TICKS(1000));
+    }
+
+    if (device_connected) {
+        ESP_LOGI(TAG, "Device connected to AP");
+        while (1) {
+            vTaskDelay(pdMS_TO_TICKS(1000));  // keep the task alive
+        }
+    }
+
+    // boot into ota_0 if no device connected to the AP after 7 seconds
+    ESP_LOGI(TAG, "No device connected to AP. Booting...");
+    esp_err_t boot_err = boot_ota0_partition();
+    if (boot_err != ESP_OK) {
+        ESP_LOGE(TAG, "Failed to boot ota_0 partition: %s",
+                 esp_err_to_name(boot_err));
+        abort();
     }
 }

--- a/vigilant-engine-recovery/main/recovery_app.c
+++ b/vigilant-engine-recovery/main/recovery_app.c
@@ -289,11 +289,30 @@ void app_main(void) {
     start_http_server();
 
     bool device_connected = false;
-    for (size_t i = 0; i < 7 && !device_connected;
-         i++)  // wait 7 seconds for a device to connect to the AP
+    for (size_t i = 0; i < 30 && !device_connected;
+         i++)  // wait 30 seconds for a device to connect to the AP
     {
-        ESP_LOGI(TAG, "Waiting for device to connect to AP... (%d/7)", i + 1);
-        vTaskDelay(pdMS_TO_TICKS(1000));
+        ESP_LOGI(TAG, "Waiting for device to connect to AP... (%d/30)", i + 1);
+
+        // check if a device is connected to the AP
+        wifi_sta_list_t sta_list;
+        ESP_ERROR_CHECK(esp_wifi_ap_get_sta_list(&sta_list));
+        if (sta_list.num > 0) {
+            device_connected = true;
+            ESP_LOGI(TAG, "Device connected to AP: %d device(s)", sta_list.num);
+            for (int j = 0; j < sta_list.num; j++) {
+                char mac_str[18];
+                snprintf(mac_str, sizeof(mac_str),
+                         "%02x:%02x:%02x:%02x:%02x:%02x",
+                         sta_list.sta[j].mac[0], sta_list.sta[j].mac[1],
+                         sta_list.sta[j].mac[2], sta_list.sta[j].mac[3],
+                         sta_list.sta[j].mac[4], sta_list.sta[j].mac[5]);
+
+                ESP_LOGI(TAG, "Connected device MAC: %s", mac_str);
+            }
+        }
+
+        vTaskDelay(pdMS_TO_TICKS(1000));  // wait 1 second before checking again
     }
 
     if (device_connected) {
@@ -303,7 +322,7 @@ void app_main(void) {
         }
     }
 
-    // boot into ota_0 if no device connected to the AP after 7 seconds
+    // boot into ota_0 if no device connected to the AP after 30 seconds
     ESP_LOGI(TAG, "No device connected to AP. Booting...");
     esp_err_t boot_err = boot_ota0_partition();
     if (boot_err != ESP_OK) {


### PR DESCRIPTION
This pull request refactors the device recovery flow to improve handling of the OTA boot process and adds logic to automatically boot into the `ota_0` partition if no device connects to the access point within 30 seconds. It also adds a developer note about future boot flag logic. The main changes are grouped below:

**Recovery Boot Flow Improvements:**

* The main task now waits up to 30 seconds for a device to connect to the Wi-Fi access point. If no device connects, the system automatically boots into the `ota_0` partition. If a device connects, the system stays in recovery mode.
* Added detailed logging for device connection attempts and connected device MAC addresses to aid debugging and monitoring.

**OTA Boot Partition Handling:**

* Refactored the OTA boot logic into a new helper function `boot_ota0_partition`, simplifying error handling and code reuse. The HTTP handler now delegates to this function.

**Developer Notes:**

* Added a prominent comment in `app_main` about planned boot flag logic to skip recovery mode in certain scenarios (e.g., when in flight), improving maintainability and future development clarity.

Closes #84 