### PR TITLE
attempt to fix CI workflow, issue #82

### DIFF
--- a/.github/workflows/esp-build.yml
+++ b/.github/workflows/esp-build.yml
@@ -76,4 +76,5 @@ jobs:
           idf.py \
             -DVE_BUILD_WEB=OFF \
             -DVE_VIGILANT_HTML="${GITHUB_WORKSPACE}/.ci-artifacts/frontend/vigilant.html" \
+            -DVE_RECOVERY_HTML="${GITHUB_WORKSPACE}/.ci-artifacts/frontend/recovery.html" \
             build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ add_compile_options("-Werror")
 # Allow CI to supply prebuilt web assets while keeping local builds automatic.
 option(VE_BUILD_WEB "Build the Vigilant UI with npm when the embedded HTML is missing" ON)
 set(VE_VIGILANT_HTML "" CACHE FILEPATH "Path to a prebuilt vigilant.html file for firmware builds")
+set(VE_RECOVERY_HTML "" CACHE FILEPATH "Path to a prebuilt recovery.html file for recovery firmware builds")
 
 if(NOT DEFINED ENV{IDF_PATH} OR "$ENV{IDF_PATH}" STREQUAL "")
   message(FATAL_ERROR
@@ -21,6 +22,7 @@ idf_build_set_property(MINIMAL_BUILD ON)
 # build properties so component logic can still read these values during that pass.
 idf_build_set_property(VE_BUILD_WEB "${VE_BUILD_WEB}")
 idf_build_set_property(VE_VIGILANT_HTML "${VE_VIGILANT_HTML}")
+idf_build_set_property(VE_RECOVERY_HTML "${VE_RECOVERY_HTML}")
 project(vigilant-engine)
 
 idf_build_get_property(VE_BUILD_DIR BUILD_DIR)
@@ -118,6 +120,7 @@ add_custom_target(ve_recovery_build ALL
             "-DSDKCONFIG=${VE_RECOVERY_SDKCONFIG}"
             "-DSDKCONFIG_DEFAULTS=${VE_RECOVERY_PROJECT_DIR}/sdkconfig.defaults"
             "-DVE_BUILD_WEB=${VE_BUILD_WEB}"
+            "-DVE_RECOVERY_HTML=${VE_RECOVERY_HTML}"
     COMMAND "${CMAKE_COMMAND}" -E env
             ${VE_RECOVERY_BUILD_ENV}
             "${CMAKE_COMMAND}" --build "${VE_RECOVERY_BUILD_DIR}"

--- a/vigilant-engine-recovery/CMakeLists.txt
+++ b/vigilant-engine-recovery/CMakeLists.txt
@@ -16,11 +16,12 @@ idf_build_set_property(MINIMAL_BUILD ON)
 
 # ---- Web UI (Vite) build integration ----
 option(VE_BUILD_WEB "Build Vite UI before compiling firmware" ON)
+set(VE_RECOVERY_HTML "" CACHE FILEPATH "Path to a prebuilt recovery HTML file")
 
 get_filename_component(VE_REPO_ROOT "${CMAKE_SOURCE_DIR}/.." ABSOLUTE)
 set(VE_NODE_ROOT_DIR "${VE_REPO_ROOT}")
 set(VE_WEB_DIR "${VE_REPO_ROOT}/vigilant-engine-frontend")
-set(VE_RECOVERY_HTML "${VE_REPO_ROOT}/build/static/recovery/index.html")
+set(VE_RECOVERY_HTML_FROM_BUILD "${VE_REPO_ROOT}/build/static/recovery/index.html")
 set(VE_ROOT_PARTITIONS_CSV "${VE_REPO_ROOT}/partitions.csv")
 set(VE_RECOVERY_PARTITIONS_CSV "${CMAKE_SOURCE_DIR}/partitions.csv")
 
@@ -29,9 +30,33 @@ if(EXISTS "${VE_ROOT_PARTITIONS_CSV}")
 endif()
 
 idf_build_set_property(VE_BUILD_WEB "${VE_BUILD_WEB}")
-idf_build_set_property(VE_RECOVERY_HTML "${VE_RECOVERY_HTML}")
 
-if(VE_BUILD_WEB)
+if(VE_RECOVERY_HTML)
+  if(IS_ABSOLUTE "${VE_RECOVERY_HTML}")
+    set(ve_recovery_html_source "${VE_RECOVERY_HTML}")
+  else()
+    get_filename_component(ve_recovery_html_source "${VE_REPO_ROOT}/${VE_RECOVERY_HTML}" ABSOLUTE)
+  endif()
+
+  if(NOT EXISTS "${ve_recovery_html_source}")
+    message(FATAL_ERROR
+      "VE_RECOVERY_HTML points to '${ve_recovery_html_source}', but that file does not exist."
+    )
+  endif()
+
+  set(ve_recovery_html "${CMAKE_BINARY_DIR}/static/recovery/index.html")
+  get_filename_component(ve_recovery_html_dir "${ve_recovery_html}" DIRECTORY)
+  file(MAKE_DIRECTORY "${ve_recovery_html_dir}")
+  configure_file("${ve_recovery_html_source}" "${ve_recovery_html}" COPYONLY)
+
+  message(STATUS "Using prebuilt Recovery UI from ${ve_recovery_html_source}")
+else()
+  set(ve_recovery_html "${VE_RECOVERY_HTML_FROM_BUILD}")
+endif()
+
+idf_build_set_property(VE_RECOVERY_HTML "${ve_recovery_html}")
+
+if(VE_BUILD_WEB AND NOT VE_RECOVERY_HTML)
   file(GLOB_RECURSE VE_WEB_SOURCES CONFIGURE_DEPENDS
     "${VE_NODE_ROOT_DIR}/package.json"
     "${VE_NODE_ROOT_DIR}/package-lock.json"
@@ -53,7 +78,7 @@ if(VE_BUILD_WEB)
   endif()
 
   add_custom_command(
-    OUTPUT "${VE_RECOVERY_HTML}"
+    OUTPUT "${ve_recovery_html}"
 
     COMMAND "${CMAKE_COMMAND}" -E chdir "${VE_NODE_ROOT_DIR}" "${NPM_EXECUTABLE}" install
     COMMAND "${CMAKE_COMMAND}" -E chdir "${VE_WEB_DIR}" "${NPM_EXECUTABLE}" install
@@ -64,7 +89,7 @@ if(VE_BUILD_WEB)
     VERBATIM
   )
 
-  add_custom_target(ve_web ALL DEPENDS "${VE_RECOVERY_HTML}")
+  add_custom_target(ve_web ALL DEPENDS "${ve_recovery_html}")
 endif()
 
 # Keep project() after ve_web so the main component can depend on the generated


### PR DESCRIPTION
Closes #82 
This pull request improves how the build system handles the Recovery UI HTML file for both main and recovery firmware builds. It introduces a new `VE_RECOVERY_HTML` CMake option, allows CI and developers to provide a prebuilt recovery UI, and ensures robust handling of the file path and existence during builds.

**Build system enhancements:**

* Added a new `VE_RECOVERY_HTML` CMake option to specify the path to a prebuilt Recovery UI HTML file for both main and recovery firmware builds. This enables supplying prebuilt assets in CI and custom builds. (`CMakeLists.txt`, `.github/workflows/esp-build.yml`) [[1]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR9) [[2]](diffhunk://#diff-1e7de1ae2d059d21e1dd75d5812d5a34b0222cef273b7c3a2af62eb747f9d20aR25) [[3]](diffhunk://#diff-f2acc065ed1004888e159a9b2d6c92f25988056a63f67b7217e0a060e24bbac7R79) [[4]](diffhunk://#diff-f090e0821f8952c5eb0dd3c82de78527eb255cd8692e35265397ca9b04d8f701R19-R24)
* Updated the recovery build process to robustly handle `VE_RECOVERY_HTML`: checks for absolute/relative paths, verifies file existence, copies the file to the build directory, and falls back to building the UI if not provided. (`vigilant-engine-recovery/CMakeLists.txt`)
* Changed all build rules and dependencies to use the resolved/copy location for the recovery HTML file, ensuring consistency in build outputs. (`vigilant-engine-recovery/CMakeLists.txt`) [[1]](diffhunk://#diff-f090e0821f8952c5eb0dd3c82de78527eb255cd8692e35265397ca9b04d8f701L56-R81) [[2]](diffhunk://#diff-f090e0821f8952c5eb0dd3c82de78527eb255cd8692e35265397ca9b04d8f701L67-R92)

These changes make the build process more flexible and reliable, especially in CI environments or when distributing prebuilt UI assets.