### PR TITLE
Attempt to fix docs CI

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -15,15 +15,12 @@ jobs:
         run: |
           git config user.name github-actions[bot]
           git config user.email 41898282+github-actions[bot]@users.noreply.github.com
-      - uses: actions/setup-python@v5
-        with:
-          python-version: 3.x
-      - run: echo "cache_id=$(date --utc '+%V')" >> $GITHUB_ENV
-      - uses: actions/cache@v4
-        with:
-          key: mkdocs-material-${{ env.cache_id }}
-          path: ~/.cache
-          restore-keys: |
-            mkdocs-material-
-      - run: pip install mkdocs-material
-      - run: mkdocs gh-deploy --force
+      - name: Install uv
+        uses: astral-sh/setup-uv@v3
+      - name: Install dependencies
+        run: |
+          [ -s .python-version ] || { echo ".python-version file is missing or empty in the repository root" >&2; exit 1; }
+          PYTHON_VERSION="$(cat .python-version)"
+          uv python install "${PYTHON_VERSION}"
+          uv sync --dev --python "${PYTHON_VERSION}"
+      - run: uv run mkdocs gh-deploy --force


### PR DESCRIPTION
This pull request updates the documentation deployment workflow to use the `uv` package manager instead of pip and improves dependency management. The main changes are:

Dependency management modernization:
* Replaced the use of `actions/setup-python` and `pip` with `astral-sh/setup-uv` for setting up Python and managing dependencies, ensuring more reproducible and faster installs.
* Added a check for the presence of a `.python-version` file and used it to specify the Python version for `uv` commands, improving version consistency and error handling.

Workflow simplification:
* Removed caching steps related to `mkdocs-material` and replaced `pip install mkdocs-material` with `uv sync --dev`, streamlining dependency installation.
* Updated the documentation deployment command to use `uv run mkdocs gh-deploy --force` instead of running mkdocs directly, ensuring the correct environment is used.

Closes #91 