### PR TITLE
Added mermaid support for mkdocs, allowing diagramms in md files.

### DIFF
--- a/docs/telemetry-pipeline.md
+++ b/docs/telemetry-pipeline.md
@@ -1,0 +1,17 @@
+# Telemetry Pipeline
+
+The Vigilant-Engine telemetry pipeline moves device measurements from firmware
+producers through encoding, transport, ingestion, and operator-facing outputs.
+
+```mermaid
+flowchart TD
+    IMU["IMU-Erfassung<br>z. B. 500 Hz"] --> Q["Messdaten-Queue"]
+    BARO["Barometer<br>z. B. 50 Hz"] --> Q
+    GPS["GNSS<br>z. B. 10 Hz"] --> Q
+    ADC["ADC / Spannung<br>z. B. 100 Hz"] --> Q
+
+    Q --> KF["Sensorfusion / Kalman-Filter"]
+    KF --> STATE["Geschätzter Zustand<br>Position, Geschwindigkeit, Lage"]
+    STATE --> LOG["Logging / Telemetrie"]
+    STATE --> CTRL["Fluglogik"]
+```

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -8,6 +8,7 @@ nav:
   - Build & Flash: build-flash.md
   - Project Layout: project-layout.md
   - Firmware Features: features.md
+  - Telemetry Pipeline: telemetry-pipeline.md
   - Configuration: config.md
   - Recovery & OTA: recovery-ota.md
   - Peripherals: peripherals.md
@@ -21,5 +22,9 @@ markdown_extensions:
   - admonition
   - toc:
       permalink: true
+
+plugins:
+  - search
+  - mermaid2
 
 theme: readthedocs

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -9,4 +9,5 @@ dependencies = [
     "pre-commit>=4.6.0",
     "mkdocs>=1.6.1",
     "clang-format>=22.1.4",
+    "mkdocs-mermaid2-plugin>=1.2.3",
 ]


### PR DESCRIPTION
This pull request adds documentation and configuration for visualizing the telemetry pipeline using Mermaid diagrams in the project documentation. The main changes include introducing a new documentation page with a Mermaid diagram, updating the MkDocs configuration to support Mermaid diagrams, and adding the necessary plugin dependency.

Documentation updates:

* Added a new `telemetry-pipeline.md` documentation page that describes the telemetry pipeline and includes a Mermaid diagram illustrating the data flow from device measurements to operator-facing outputs.
* Updated the `mkdocs.yml` navigation to include the new Telemetry Pipeline page.

Mermaid diagram support:

* Added the `mkdocs-mermaid2-plugin` to the `pyproject.toml` dependencies to enable Mermaid diagram rendering.
* Configured MkDocs to use the `mermaid2` plugin by updating the `mkdocs.yml` file.