### PR TITLE
added multi byte i2c reads and writes

### DIFF
--- a/components/vigilant_engine/include/i2c.h
+++ b/components/vigilant_engine/include/i2c.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include <stddef.h>
+#include <stdint.h>
 
 #include "esp_err.h"
 #include "vigilant_i2c_device.h"
@@ -14,6 +15,10 @@ esp_err_t i2c_add_device(VigilantI2CDevice* device);
 esp_err_t i2c_remove_device(VigilantI2CDevice* device);
 esp_err_t i2c_set_reg8(VigilantI2CDevice* device, uint8_t reg, uint8_t value);
 esp_err_t i2c_read_reg8(VigilantI2CDevice* device, uint8_t reg, uint8_t* value);
+esp_err_t i2c_read_regs(VigilantI2CDevice* device, uint8_t reg, uint8_t* data,
+                        size_t len);
+esp_err_t i2c_write_regs(VigilantI2CDevice* device, uint8_t reg,
+                         const uint8_t* data, size_t len);
 esp_err_t i2c_whoami_check(VigilantI2CDevice* device);
 esp_err_t i2c_get_detected_devices(uint8_t* addresses, size_t max_addresses,
                                    size_t* count);

--- a/components/vigilant_engine/include/vigilant.h
+++ b/components/vigilant_engine/include/vigilant.h
@@ -1,5 +1,8 @@
 #pragma once
 
+#include <stddef.h>
+#include <stdint.h>
+
 #include "esp_err.h"
 #include "vigilant_i2c_device.h"
 
@@ -45,6 +48,10 @@ esp_err_t vigilant_i2c_set_reg8(VigilantI2CDevice* device, uint8_t reg,
                                 uint8_t value);
 esp_err_t vigilant_i2c_read_reg8(VigilantI2CDevice* device, uint8_t reg,
                                  uint8_t* value);
+esp_err_t vigilant_i2c_read_regs(VigilantI2CDevice* device, uint8_t reg,
+                                 uint8_t* data, size_t len);
+esp_err_t vigilant_i2c_write_regs(VigilantI2CDevice* device, uint8_t reg,
+                                  const uint8_t* data, size_t len);
 esp_err_t vigilant_i2c_whoami_check(VigilantI2CDevice* device);
 
 #ifdef __cplusplus

--- a/components/vigilant_engine/src/i2c.c
+++ b/components/vigilant_engine/src/i2c.c
@@ -13,7 +13,7 @@
 #define I2C_SDA_IO CONFIG_VE_I2C_SDA_IO
 #define I2C_PORT I2C_NUM_0
 #define I2C_FREQ_HZ CONFIG_VE_I2C_FREQ_HZ
-#define I2C_TIMEOUT_MS 50
+#define I2C_TIMEOUT_MS 100
 
 static const char* TAG = "ve_i2c";
 static i2c_master_bus_handle_t s_i2c_bus = NULL;
@@ -183,42 +183,71 @@ esp_err_t i2c_remove_device(VigilantI2CDevice* device) {
     return err;
 }
 
-esp_err_t i2c_set_reg8(VigilantI2CDevice* device, uint8_t reg, uint8_t value) {
+esp_err_t i2c_read_regs(VigilantI2CDevice* device, uint8_t reg, uint8_t* data,
+                        size_t len) {
     if (!device) {
-        ESP_LOGE(TAG, "Cannot write reg 0x%02X: device object is NULL", reg);
+        ESP_LOGE(TAG, "Cannot read register 0x%02X: device object is NULL",
+                 reg);
         return ESP_ERR_INVALID_ARG;
     }
     if (!device->handle) {
         ESP_LOGE(TAG,
-                 "Cannot write reg 0x%02X: device 0x%02X has no handle. Call "
-                 "i2c_add_device() first.",
+                 "Cannot read register 0x%02X: device 0x%02X has no handle. "
+                 "Call i2c_add_device() first.",
                  reg, (unsigned int)device->address);
         return ESP_ERR_INVALID_ARG;
     }
+    if (!data && len > 0) {
+        ESP_LOGE(TAG, "Cannot read register 0x%02X: output buffer is NULL",
+                 reg);
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (len == 0) {
+        return ESP_OK;
+    }
 
-    uint8_t payload[] = {reg, value};
-    return i2c_master_transmit(device->handle, payload, sizeof(payload), 100);
+    return i2c_master_transmit_receive(device->handle, &reg, 1, data, len,
+                                       I2C_TIMEOUT_MS);
+}
+
+esp_err_t i2c_write_regs(VigilantI2CDevice* device, uint8_t reg,
+                         const uint8_t* data, size_t len) {
+    if (!device) {
+        ESP_LOGE(TAG, "Cannot write register 0x%02X: device object is NULL",
+                 reg);
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (!device->handle) {
+        ESP_LOGE(TAG,
+                 "Cannot write register 0x%02X: device 0x%02X has no handle. "
+                 "Call i2c_add_device() first.",
+                 reg, (unsigned int)device->address);
+        return ESP_ERR_INVALID_ARG;
+    }
+    if (!data && len > 0) {
+        ESP_LOGE(TAG, "Cannot write register 0x%02X: data buffer is NULL",
+                 reg);
+        return ESP_ERR_INVALID_ARG;
+    }
+
+    i2c_master_transmit_multi_buffer_info_t buffers[2] = {
+        {.write_buffer = &reg, .buffer_size = 1},
+        {.write_buffer = data, .buffer_size = len},
+    };
+    size_t buffer_count = (len > 0) ? 2 : 1;
+
+    return i2c_master_multi_buffer_transmit(device->handle, buffers,
+                                            buffer_count,
+                                            I2C_TIMEOUT_MS);
+}
+
+esp_err_t i2c_set_reg8(VigilantI2CDevice* device, uint8_t reg, uint8_t value) {
+    return i2c_write_regs(device, reg, &value, 1);
 }
 
 esp_err_t i2c_read_reg8(VigilantI2CDevice* device, uint8_t reg,
                         uint8_t* value) {
-    if (!device) {
-        ESP_LOGE(TAG, "Cannot read reg 0x%02X: device object is NULL", reg);
-        return ESP_ERR_INVALID_ARG;
-    }
-    if (!device->handle) {
-        ESP_LOGE(TAG,
-                 "Cannot read reg 0x%02X: device 0x%02X has no handle. Call "
-                 "i2c_add_device() first.",
-                 reg, (unsigned int)device->address);
-        return ESP_ERR_INVALID_ARG;
-    }
-    if (!value) {
-        ESP_LOGE(TAG, "Cannot read reg 0x%02X: output buffer is NULL", reg);
-        return ESP_ERR_INVALID_ARG;
-    }
-
-    return i2c_master_transmit_receive(device->handle, &reg, 1, value, 1, 100);
+    return i2c_read_regs(device, reg, value, 1);
 }
 
 esp_err_t i2c_whoami_check(VigilantI2CDevice* device) {

--- a/components/vigilant_engine/src/i2c.c
+++ b/components/vigilant_engine/src/i2c.c
@@ -225,8 +225,7 @@ esp_err_t i2c_write_regs(VigilantI2CDevice* device, uint8_t reg,
         return ESP_ERR_INVALID_ARG;
     }
     if (!data && len > 0) {
-        ESP_LOGE(TAG, "Cannot write register 0x%02X: data buffer is NULL",
-                 reg);
+        ESP_LOGE(TAG, "Cannot write register 0x%02X: data buffer is NULL", reg);
         return ESP_ERR_INVALID_ARG;
     }
 
@@ -237,8 +236,7 @@ esp_err_t i2c_write_regs(VigilantI2CDevice* device, uint8_t reg,
     size_t buffer_count = (len > 0) ? 2 : 1;
 
     return i2c_master_multi_buffer_transmit(device->handle, buffers,
-                                            buffer_count,
-                                            I2C_TIMEOUT_MS);
+                                            buffer_count, I2C_TIMEOUT_MS);
 }
 
 esp_err_t i2c_set_reg8(VigilantI2CDevice* device, uint8_t reg, uint8_t value) {

--- a/components/vigilant_engine/src/vigilant.c
+++ b/components/vigilant_engine/src/vigilant.c
@@ -405,6 +405,32 @@ esp_err_t vigilant_i2c_read_reg8(VigilantI2CDevice* device, uint8_t reg,
 #endif
 }
 
+esp_err_t vigilant_i2c_read_regs(VigilantI2CDevice* device, uint8_t reg,
+                                 uint8_t* data, size_t len) {
+#if CONFIG_VE_ENABLE_I2C
+    return i2c_read_regs(device, reg, data, len);
+#else
+    (void)device;
+    (void)reg;
+    (void)data;
+    (void)len;
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+}
+
+esp_err_t vigilant_i2c_write_regs(VigilantI2CDevice* device, uint8_t reg,
+                                  const uint8_t* data, size_t len) {
+#if CONFIG_VE_ENABLE_I2C
+    return i2c_write_regs(device, reg, data, len);
+#else
+    (void)device;
+    (void)reg;
+    (void)data;
+    (void)len;
+    return ESP_ERR_NOT_SUPPORTED;
+#endif
+}
+
 esp_err_t vigilant_i2c_whoami_check(VigilantI2CDevice* device) {
 #if CONFIG_VE_ENABLE_I2C
     return i2c_whoami_check(device);

--- a/docs/i2c-interface.md
+++ b/docs/i2c-interface.md
@@ -24,6 +24,8 @@ When enabled, Vigilant Engine builds the I2C driver, creates the bus during star
 - Optionally verify identity with `vigilant_i2c_whoami_check(&device)`
 - Write single-byte registers with `vigilant_i2c_set_reg8(&device, reg, value)`
 - Read single-byte registers with `vigilant_i2c_read_reg8(&device, reg, &value)`
+- For multi-byte payloads (e.g. sensor data blocks) use `vigilant_i2c_read_regs(...)` and
+  `vigilant_i2c_write_regs(...)`
 - Remove the device with `vigilant_i2c_remove_device(&device)` if you no longer need it
 
 If I2C is disabled in menuconfig, the public `vigilant_i2c_*` helpers return `ESP_ERR_NOT_SUPPORTED`.
@@ -113,6 +115,36 @@ Reads the register stored in `device->whoami_reg` and compares it against `devic
 - `ESP_ERR_INVALID_RESPONSE` The device responded, but the WHOAMI value did not match
 - `ESP_ERR_NOT_SUPPORTED` I2C support is disabled in menuconfig
 
+___
+#### `vigilant_i2c_read_regs`, **function**
+Reads a block of `len` bytes starting at register `reg`. All devices use 8-bit register addressing.
+
+###### Parameters:
+- `device` Pointer to the `VigilantI2CDevice` object to read from
+- `reg` Register address to transmit before reading
+- `data` Output buffer of at least `len` bytes
+- `len` Number of bytes to read
+
+###### Returns:
+- `ESP_OK` Block read succeeded
+- `ESP_ERR_INVALID_ARG` `device` is `NULL`, the device was not added, or `data` is `NULL` with `len > 0`
+- `ESP_ERR_NOT_SUPPORTED` I2C support is disabled in menuconfig
+
+___
+#### `vigilant_i2c_write_regs`, **function**
+Writes a block of `len` bytes to the register block starting at `reg`.
+
+###### Parameters:
+- `device` Pointer to the `VigilantI2CDevice` object to write to
+- `reg` Register address to transmit before the data
+- `data` Data buffer to write
+- `len` Number of bytes to write
+
+###### Returns:
+- `ESP_OK` Block write succeeded
+- `ESP_ERR_INVALID_ARG` `device` is `NULL`, the device was not added, or `data` is `NULL` with `len > 0`
+- `ESP_ERR_NOT_SUPPORTED` I2C support is disabled in menuconfig
+
 ## Low-level I2C functions
 
 These functions exist in the I2C component itself. In normal application code, prefer the
@@ -143,6 +175,14 @@ ___
 Low-level variant of `vigilant_i2c_read_reg8(...)`. Reads one 8-bit register from a device.
 
 ___
+#### `i2c_read_regs`, **function**
+Low-level variant of `vigilant_i2c_read_regs(...)`. Reads a block of bytes starting at a register.
+
+___
+#### `i2c_write_regs`, **function**
+Low-level variant of `vigilant_i2c_write_regs(...)`. Writes a block of bytes to a register block.
+
+___
 #### `i2c_whoami_check`, **function**
 Low-level variant of `vigilant_i2c_whoami_check(...)`. Compares the returned WHOAMI value with the expected one.
 
@@ -154,25 +194,36 @@ application startup flow.
 ## Example
 
 ```c
-VigilantI2CDevice accel = {
-    .address = 0x18,
-    .whoami_reg = 0x0F,
-    .expected_whoami = 0x33,
+// LSM6DSV320X high-G IMU (ST): accel + gyro over I2C
+VigilantI2CDevice imu = {
+    .address = 0x6A,
+    .whoami_reg = 0x0F,     // WHO_AM_I register
+    .expected_whoami = 0x70,
     .handle = NULL,
 };
 
-ESP_ERROR_CHECK(vigilant_i2c_add_device(&accel));
-ESP_ERROR_CHECK(vigilant_i2c_whoami_check(&accel));
-ESP_ERROR_CHECK(vigilant_i2c_set_reg8(&accel, 0x20, 0x57));
+ESP_ERROR_CHECK(vigilant_i2c_add_device(&imu));
+ESP_ERROR_CHECK(vigilant_i2c_whoami_check(&imu));
 
-uint8_t ctrl_reg = 0;
-ESP_ERROR_CHECK(vigilant_i2c_read_reg8(&accel, 0x20, &ctrl_reg));
+// Configure accelerometer: set ODR + full scale in CTRL1_XL (0x10)
+vigilant_i2c_write_regs(&imu, 0x10, (const uint8_t[]){0x60}, 1);
+
+// Burst-read the 12-byte data block: OUTX_L_XL (0x28) .. OUTZ_H_G (0x2D)
+uint8_t data[12] = {0};
+ESP_ERROR_CHECK(vigilant_i2c_read_regs(&imu, 0x28, data, sizeof(data)));
+
+// Single-register access works the same way
+uint8_t status = 0;
+ESP_ERROR_CHECK(vigilant_i2c_read_reg8(&imu, 0x1E, &status));
 ```
 
 Use the device-specific address, register map, and expected WHOAMI value from your peripheral datasheet.
 
 ## Notes
 
+- All devices use 8-bit register addressing
 - `vigilant_i2c_set_reg8(...)` and `vigilant_i2c_read_reg8(...)` operate on one 8-bit register at a time
+- `vigilant_i2c_read_regs(...)` / `vigilant_i2c_write_regs(...)` handle multi-byte blocks, e.g. the
+  contiguous sensor data registers most IMUs/pressure sensors expose
 - The I2C bus is shared, so multiple devices can be added as separate `VigilantI2CDevice` objects
 - `vigilant_i2c_add_device(...)` must be called before any read, write, or WHOAMI check


### PR DESCRIPTION

i implemented a small i2c extension, to make interfacing our sensors easier.

- implemented multi byte i2c reads and writes using the appropriate esp-idf functions in i2c.h and i2c.c
  -> because it is using esp-idf internal functions it is thread-safe from the get-go
- updated the needed boilerplate in vigilant.c and  vigilant.h
- updated the docs
- added i2c example to docs with the high g imu we have on the core

the only necessary files for quick review (<10 minutes) should be i2c.h and i2c.c, please do it quickly if possible :)