### PR TITLE
docs: add GitHub repo link

### DIFF
--- a/docs/mkdocs_hooks.py
+++ b/docs/mkdocs_hooks.py
@@ -11,8 +11,16 @@ def on_config(config):
             capture_output=True,
             text=True,
         ).stdout.strip()
+        commit_tree = subprocess.run(
+            ["git", "rev-parse", "HEAD"],
+            check=True,
+            capture_output=True,
+            text=True,
+        ).stdout.strip()
     except (FileNotFoundError, subprocess.CalledProcessError):
         commit_hash = "unknown"
+        commit_tree = "unknown"
 
     config.extra["commit_hash"] = commit_hash
+    config.extra["commit_tree_url"] = f"{config.repo_url}/tree/{commit_tree}"
     return config

--- a/docs/overrides/footer.html
+++ b/docs/overrides/footer.html
@@ -24,9 +24,9 @@
 
   <p>
     {%- if config.extra.commit_hash %}
-      Based on commit {{ config.extra.commit_hash }} -
+      Based on commit <a href="{{ config.extra.commit_tree_url }}" target="_blank" rel="noopener noreferrer">{{ config.extra.commit_hash }}</a> -
     {%- endif %}
-    <a href="{{ config.repo_url }}" target="_blank" rel="noopener noreferrer">GitHub</a>
+    <a href="{{ config.repo_url }}" target="_blank" rel="noopener noreferrer">GitHub Repository</a>
     {% trans mkdocs_link='<a href="https://www.mkdocs.org/">MkDocs</a>', sphinx_link='<a href="https://github.com/readthedocs/sphinx_rtd_theme">{}</a>'.format(gettext('theme')), rtd_link='<a href="https://readthedocs.org">Read the Docs</a>' %} - Built with %(mkdocs_link)s using a %(sphinx_link)s provided by %(rtd_link)s.{% endtrans %}
   </p>
 </footer>

--- a/docs/overrides/footer.html
+++ b/docs/overrides/footer.html
@@ -26,6 +26,7 @@
     {%- if config.extra.commit_hash %}
       Based on commit {{ config.extra.commit_hash }} -
     {%- endif %}
-    {% trans mkdocs_link='<a href="https://www.mkdocs.org/">MkDocs</a>', sphinx_link='<a href="https://github.com/readthedocs/sphinx_rtd_theme">{}</a>'.format(gettext('theme')), rtd_link='<a href="https://readthedocs.org">Read the Docs</a>' %}Built with %(mkdocs_link)s using a %(sphinx_link)s provided by %(rtd_link)s.{% endtrans %}
+    <a href="{{ config.repo_url }}" target="_blank" rel="noopener noreferrer">GitHub</a>
+    {% trans mkdocs_link='<a href="https://www.mkdocs.org/">MkDocs</a>', sphinx_link='<a href="https://github.com/readthedocs/sphinx_rtd_theme">{}</a>'.format(gettext('theme')), rtd_link='<a href="https://readthedocs.org">Read the Docs</a>' %} - Built with %(mkdocs_link)s using a %(sphinx_link)s provided by %(rtd_link)s.{% endtrans %}
   </p>
 </footer>

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,8 @@
 site_name: Vigilant Engine Documentation
 site_description: Documentation for the Vigilant Engine ESP-IDF framework
 site_dir: site
+repo_name: GitHub
+repo_url: https://github.com/bears-space/vigilant-engine
 
 nav:
   - Home: index.md


### PR DESCRIPTION
This PR adds a link to the GitHub repo to the docs pages.

Closes #101 